### PR TITLE
Remove NGHTTP2_CONTINUATION

### DIFF
--- a/mod_h2/h2_session.c
+++ b/mod_h2/h2_session.c
@@ -327,8 +327,7 @@ static int on_frame_recv_cb(nghttp2_session *ng2s,
     }
     apr_status_t status = APR_SUCCESS;
     switch (frame->hd.type) {
-        case NGHTTP2_HEADERS:
-        case NGHTTP2_CONTINUATION: {
+        case NGHTTP2_HEADERS: {
             h2_stream * stream = h2_stream_set_get(session->streams,
                                                    frame->hd.stream_id);
             if (stream == NULL) {

--- a/mod_h2/h2_util.c
+++ b/mod_h2/h2_util.c
@@ -111,13 +111,6 @@ int h2_util_frame_print(const nghttp2_frame *frame, char *buffer, size_t maxlen)
                                 "WINDOW_UPDATE[length=%d, stream=%d]",
                                 (int)frame->hd.length, frame->hd.stream_id);
         }
-        case NGHTTP2_CONTINUATION: {
-            return apr_snprintf(buffer, maxlen,
-                                "CONTINUATION[length=%d, hend=%dm, stream=%d]",
-                                (int)frame->hd.length,
-                                !!(frame->hd.flags & NGHTTP2_FLAG_END_HEADERS),
-                                frame->hd.stream_id);
-        }
         default:
             return apr_snprintf(buffer, maxlen,
                          "FRAME[type=%d, length=%d, flags=%d, stream=%d]",


### PR DESCRIPTION
Although nghttp2 API lists NGHTTP2_CONTINUATION in nghttp2_frame_type,
it won't be passed to any callbacks.  This is because the library
processes preceding HEADERS/PUSH_RPOMISE and following CONTINUATION
frames as single frame.