### PR TITLE
initialize r->server like ap_read_request would

### DIFF
--- a/mod_h2/h2_config.c
+++ b/mod_h2/h2_config.c
@@ -344,7 +344,7 @@ h2_config *h2_config_get(conn_rec *c)
             r.headers_in = apr_table_make(c->pool, 1);
             r.parsed_uri = uri;
             r.status = HTTP_OK;
-            
+            r.server = r.connection->base_server;
             ap_update_vhost_from_headers(&r);
             ctx->server = r.server;
         }


### PR DESCRIPTION
For me, this avoids a crash in ap_update_vhost_from_headers() but
it's unclear to me if ap_update_vhost_from_headers() is really
doing anything for us if the request data is all dummied anyway.

(don't get too excited, I was only trying to kick the tires. Also I'm not really a git or github user so bare with me)