### PR TITLE
Use plain shell

### DIFF
--- a/setup/Makefile.am
+++ b/setup/Makefile.am
@@ -26,4 +26,4 @@ SYSCONF_DIR = @SYSCONF_DIR@
 
 # overwrite install target
 install:
-	@bash install-config.sh $(SYSCONF_DIR) $(DESTDIR)
+	@sh install-config.sh $(SYSCONF_DIR) $(DESTDIR)


### PR DESCRIPTION
Makefile invokes bash whereas the script executed uses #!/bin/sh shebang. This fails on platforms that do not ship with bash.