### PR TITLE
Properly fix build on i386

### DIFF
--- a/mod_http2/h2_push.c
+++ b/mod_http2/h2_push.c
@@ -792,7 +792,7 @@ static apr_status_t gset_encode_next(gset_encoder *encoder, apr_uint64_t pval)
     flex_bits = (delta >> encoder->fixed_bits);
     ap_log_perror(APLOG_MARK, GCSLOG_LEVEL, 0, encoder->pool,
                   "h2_push_diary_enc: val=%"APR_UINT64_T_HEX_FMT", delta=%"
-                  APR_UINT64_T_HEX_FMT" flex_bits=%lld, "
+                  APR_UINT64_T_HEX_FMT" flex_bits=%"APR_UINT64_T_FMT", "
                   "fixed_bits=%d, fixed_val=%"APR_UINT64_T_HEX_FMT, 
                   pval, delta, flex_bits, encoder->fixed_bits, delta&encoder->fixed_mask);
     for (; flex_bits != 0; --flex_bits) {


### PR DESCRIPTION
This fixes building on both i386 and amd64.
Culprit and fix both in include/apr-1/apr.h
```
#ifdef __LP64__
...
 typedef  unsigned long   apr_uint64_t;
...
#else
...
 typedef  unsigned long long   apr_uint64_t;
...
#endif
```
The fix is also in there
```
#ifdef __LP64__
...
 #define APR_UINT64_T_FMT     "lu"
...
#else
...
 #define APR_UINT64_T_FMT     "llu"
...
#endif
```
