### PR TITLE
#99 Fix compilation with httpd 2.4.20

### DIFF
--- a/mod_http2/h2_bucket_beam.c
+++ b/mod_http2/h2_bucket_beam.c
@@ -103,7 +103,7 @@ static apr_bucket *h2_beam_bucket_create(h2_bucket_beam *beam,
     return h2_beam_bucket_make(b, beam, bred);
 }
 
-APU_DECLARE_DATA const apr_bucket_type_t h2_bucket_type_beam = {
+extern const apr_bucket_type_t h2_bucket_type_beam = {
     "BEAM", 5, APR_BUCKET_DATA,
     beam_bucket_destroy,
     beam_bucket_read,

--- a/mod_http2/h2_util.c
+++ b/mod_http2/h2_util.c
@@ -1520,7 +1520,7 @@ static const unsigned char ucharmap[] = {
 };
 #endif
 
-AP_DECLARE(int) h2_casecmpstr(const char *s1, const char *s2)
+int h2_casecmpstr(const char *s1, const char *s2)
 {
     const unsigned char *ps1 = (const unsigned char *) s1;
     const unsigned char *ps2 = (const unsigned char *) s2;
@@ -1534,7 +1534,7 @@ AP_DECLARE(int) h2_casecmpstr(const char *s1, const char *s2)
     return (ucharmap[*ps1] - ucharmap[*ps2]);
 }
 
-AP_DECLARE(int) h2_casecmpstrn(const char *s1, const char *s2, apr_size_t n)
+int h2_casecmpstrn(const char *s1, const char *s2, apr_size_t n)
 {
     const unsigned char *ps1 = (const unsigned char *) s1;
     const unsigned char *ps2 = (const unsigned char *) s2;


### PR DESCRIPTION
@icing This fixes compilatiion with Apache httpd 2.4.20

There was a redefinition in h2_bucket_beam.c as well. Line 106 redefined h2_bucket_type_beam in line 36:

    .\h2_bucket_beam.c(106): error C2370: 'h2_bucket_type_beam' : redefinition; different storage class
    .\h2_bucket_beam.c(106): error C2491: 'h2_bucket_type_beam' : definition of dllimport data not allowed

Note: in the mod_http2.dsp of the Apache sources h2_bucket_beam.c has to be added. 