### PR TITLE
Support downgrade to HTTP 1.1 for subrequests

### DIFF
--- a/mod_http2/h2_headers.c
+++ b/mod_http2/h2_headers.c
@@ -129,16 +129,20 @@ h2_headers *h2_headers_rcreate(request_rec *r, int status,
 {
     h2_headers *headers = h2_headers_create(status, header, r->notes, 0, pool);
     if (headers->status == HTTP_FORBIDDEN) {
-        const char *cause = apr_table_get(r->notes, "ssl-renegotiate-forbidden");
-        if (cause) {
-            /* This request triggered a TLS renegotiation that is now allowed 
-             * in HTTP/2. Tell the client that it should use HTTP/1.1 for this.
-             */
-            ap_log_rerror(APLOG_MARK, APLOG_DEBUG, headers->status, r,
-                          APLOGNO(03061) 
-                          "h2_headers(%ld): renegotiate forbidden, cause: %s",
-                          (long)r->connection->id, cause);
-            headers->status = H2_ERR_HTTP_1_1_REQUIRED;
+        request_rec *r_prev;
+        for (r_prev = r; r_prev != NULL; r_prev = r_prev->prev) {
+            const char *cause = apr_table_get(r_prev->notes, "ssl-renegotiate-forbidden");
+            if (cause) {
+                /* This request triggered a TLS renegotiation that is not allowed
+                 * in HTTP/2. Tell the client that it should use HTTP/1.1 for this.
+                 */
+                ap_log_rerror(APLOG_MARK, APLOG_DEBUG, headers->status, r,
+                              APLOGNO(03061)
+                              "h2_headers(%ld): renegotiate forbidden, cause: %s",
+                              (long)r->connection->id, cause);
+                headers->status = H2_ERR_HTTP_1_1_REQUIRED;
+                break;
+            }
         }
     }
     if (is_unsafe(r->server)) {


### PR DESCRIPTION
When accessing a location that needs a client certificate, a downgrade
to HTTP 1.1 may be necessary if the current connection uses HTTP/2.
This must be done because HTTP/2 does not allow SSL renegotiations.

mod_h2 already handles this case, it sets a request note
"ssl-renegotiate-forbidden" and later evaluates it in
h2_headers_rcreate(). An RST_STREAM is sent to the client with the
error code HTTP_1_1_REQUIRED.

This did not work if there are custom error pages configured with
ErrorDocument. To show these error pages, Apache creates an internal
redirection in ap_die_r(). This creates a new internal request which
does not have the "ssl-renegotiate-forbidden" note.

Bugfix: Also look for the request note in linked requests.

Fixes #172