### PR TITLE
include string.h for via h2_private

### DIFF
--- a/mod_http2/h2_private.h
+++ b/mod_http2/h2_private.h
@@ -21,6 +21,10 @@
 
 #include <nghttp2/nghttp2.h>
 
+#if APR_HAVE_STRING_H
+#include <string.h>
+#endif
+
 extern module AP_MODULE_DECLARE_DATA http2_module;
 
 APLOG_USE_MODULE(http2);


### PR DESCRIPTION
12/19 *.c files use strcmp or strcpy.

On my AIX system, the linker gets confused and looks for strcmp and
friends in libssl (confirmed with dump -tv).

Since APR already has an APR_HAVE macro for string.h, just include
it from h2_private.h