### PR TITLE
Header too long, too many headers: log at level "info"

### DIFF
--- a/mod_http2/h2_stream.c
+++ b/mod_http2/h2_stream.c
@@ -704,15 +704,18 @@ apr_status_t h2_stream_add_header(h2_stream *stream,
     if (name[0] == ':') {
         if ((vlen) > session->s->limit_req_line) {
             /* pseudo header: approximation of request line size check */
-            ap_log_cerror(APLOG_MARK, APLOG_TRACE1, 0, session->c,
-                          H2_STRM_MSG(stream, "pseudo %s too long"), name);
+            ap_log_cerror(APLOG_MARK, APLOG_INFO, 0, session->c,
+                          H2_STRM_MSG(stream, "Request pseudo header exceeds "
+                          "LimitRequestFieldSize: %s"), name);
             error = HTTP_REQUEST_URI_TOO_LARGE;
         }
     }
     else if ((nlen + 2 + vlen) > session->s->limit_req_fieldsize) {
         /* header too long */
-        ap_log_cerror(APLOG_MARK, APLOG_TRACE1, 0, session->c,
-                      H2_STRM_MSG(stream, "header %s too long"), name);
+        ap_log_cerror(APLOG_MARK, APLOG_INFO, 0, session->c,
+                      H2_STRM_MSG(stream, "Request header exceeds "
+                      "LimitRequestFieldSize: %.*s"),
+                      H2MIN(nlen, 80), name);
         error = HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE;
     }
     
@@ -724,8 +727,9 @@ apr_status_t h2_stream_add_header(h2_stream *stream,
             h2_stream_rst(stream, H2_ERR_ENHANCE_YOUR_CALM);
             return APR_ECONNRESET;
         }
-        ap_log_cerror(APLOG_MARK, APLOG_TRACE1, 0, session->c,
-                      H2_STRM_MSG(stream, "too many header lines")); 
+        ap_log_cerror(APLOG_MARK, APLOG_INFO, 0, session->c,
+                      H2_STRM_MSG(stream, "Number of request headers exceeds "
+                      "LimitRequestFields"));
         error = HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE;
     }
     


### PR DESCRIPTION
If a header is too long or if there are too many headers, log similar messages
and use the same log level as for the corresponding log messages in HTTP 1.x