### PR TITLE
Log too long/too many headers only once per request

### DIFF
--- a/mod_http2/h2_stream.c
+++ b/mod_http2/h2_stream.c
@@ -696,19 +696,23 @@ apr_status_t h2_stream_add_header(h2_stream *stream,
     if (name[0] == ':') {
         if ((vlen) > session->s->limit_req_line) {
             /* pseudo header: approximation of request line size check */
-            ap_log_cerror(APLOG_MARK, APLOG_INFO, 0, session->c,  
-                          H2_STRM_LOG(APLOGNO(10178), stream, 
-                                      "Request pseudo header exceeds "
-                                      "LimitRequestFieldSize: %s"), name);
+            if (!h2_stream_is_ready(stream)) {
+                ap_log_cerror(APLOG_MARK, APLOG_INFO, 0, session->c,
+                              H2_STRM_LOG(APLOGNO(10178), stream,
+                                          "Request pseudo header exceeds "
+                                          "LimitRequestFieldSize: %s"), name);
+            }
             error = HTTP_REQUEST_URI_TOO_LARGE;
         }
     }
     else if ((nlen + 2 + vlen) > session->s->limit_req_fieldsize) {
         /* header too long */
-        ap_log_cerror(APLOG_MARK, APLOG_INFO, 0, session->c,  
-                      H2_STRM_LOG(APLOGNO(10180), stream,"Request header exceeds "
-                                  "LimitRequestFieldSize: %.*s"),
-                      (int)H2MIN(nlen, 80), name);
+        if (!h2_stream_is_ready(stream)) {
+            ap_log_cerror(APLOG_MARK, APLOG_INFO, 0, session->c,
+                          H2_STRM_LOG(APLOGNO(10180), stream,"Request header exceeds "
+                                      "LimitRequestFieldSize: %.*s"),
+                          (int)H2MIN(nlen, 80), name);
+        }
         error = HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE;
     }
     
@@ -720,9 +724,11 @@ apr_status_t h2_stream_add_header(h2_stream *stream,
             h2_stream_rst(stream, H2_ERR_ENHANCE_YOUR_CALM);
             return APR_ECONNRESET;
         }
-        ap_log_cerror(APLOG_MARK, APLOG_INFO, 0, session->c, 
-                      H2_STRM_LOG(APLOGNO(10181), stream, "Number of request headers "
-                                  "exceeds LimitRequestFields"));
+        if (!h2_stream_is_ready(stream)) {
+            ap_log_cerror(APLOG_MARK, APLOG_INFO, 0, session->c,
+                          H2_STRM_LOG(APLOGNO(10181), stream, "Number of request headers "
+                                      "exceeds LimitRequestFields"));
+        }
         error = HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE;
     }
     
@@ -782,10 +788,12 @@ apr_status_t h2_stream_end_headers(h2_stream *stream, int eos, size_t raw_bytes)
         ctx.failed_key = NULL;
         apr_table_do(table_check_val_len, &ctx, stream->request->headers, NULL);
         if (ctx.failed_key) {
-            ap_log_cerror(APLOG_MARK, APLOG_INFO, 0, stream->session->c,  
-                          H2_STRM_LOG(APLOGNO(), stream,"Request header exceeds "
-                                      "LimitRequestFieldSize: %.*s"),
-                          (int)H2MIN(strlen(ctx.failed_key), 80), ctx.failed_key);
+            if (!h2_stream_is_ready(stream)) {
+                ap_log_cerror(APLOG_MARK, APLOG_INFO, 0, stream->session->c,
+                              H2_STRM_LOG(APLOGNO(), stream,"Request header exceeds "
+                                          "LimitRequestFieldSize: %.*s"),
+                              (int)H2MIN(strlen(ctx.failed_key), 80), ctx.failed_key);
+            }
             set_error_response(stream, HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE);
             /* keep on returning APR_SUCCESS, so that we send a HTTP response and
              * do not RST the stream. */


### PR DESCRIPTION
Log violations of LimitRequestFieldSize and LimitRequestFields only once per request (same behavior as for HTTP 1.x)

Without this change, up to 100 log messages per request are possible.