### PR TITLE
Distribute Makefile.am, so tests are executable without need to

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@ DIST_SUBDIRS    = mod_http2
 
 ACLOCAL_AMFLAGS = -I m4
 
-EXTRA_DIST     = test/e2e test/unit test/Makefile.in
+EXTRA_DIST     = test/e2e test/unit test/Makefile.in test/Makefile.am
 
 
 dist_doc_DATA   = README README.md LICENSE


### PR DESCRIPTION
create tests/Makefile.am.

Hi Stefan,

I was trying to build and run upstream test suite from dist tarball, but when I was trying to run "make test", it will fail since Makefile.am is needed as dependency:

$ make test >test.output'
make[1]: *** No rule to make target 'Makefile.am', needed by 'Makefile.in'.  Stop.
make: *** [Makefile:923: test] Error 2

I can workaround it by:

$ touch test/Makefile.am
$ touch test/Makefile.in
$ make test

but anyway, when I want to make some changes in Makefile.am and regenerate it, I can't do so.
