### PR TITLE
test: replace capture_output with subprocess.PIPE

### DIFF
--- a/test/e2e/TestEnv.py
+++ b/test/e2e/TestEnv.py
@@ -96,7 +96,7 @@ class TestEnv:
     @classmethod
     def run( cls, args, input=None ) :
         print("execute: %s" % " ".join(args))
-        p = subprocess.run(args, capture_output=True)
+        p = subprocess.run(args, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         rv = p.returncode
         print("exit code %d, stderr:\n%s" % (rv, p.stderr.decode('utf-8')))
         try:
@@ -168,7 +168,7 @@ class TestEnv:
         args = [cls.APACHECTL, "-d", cls.WEBROOT, "-k", cmd]
         print("execute: %s" % " ".join(args))
         cls.apachectl_stderr = ""
-        p = subprocess.run(args, capture_output=True, text=True)
+        p = subprocess.run(args, stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
         sys.stderr.write(p.stderr)
         rv = p.returncode
         if rv == 0:

--- a/test/e2e/TestNghttp.py
+++ b/test/e2e/TestNghttp.py
@@ -302,7 +302,7 @@ Content-Transfer-Encoding: binary
 
     def _run( self, args, input=None ) :
         print(("execute: %s" % " ".join(args)))
-        p = subprocess.run(args, capture_output=True)
+        p = subprocess.run(args, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         rv = p.returncode
         print("stderr: %s" % p.stderr)
         try:


### PR DESCRIPTION
The capture_output arg in subprocess.run is available
only for Python 3.7, meanwhile the version with PIPE
is compatible with more versions (3.5+ mostly).
This allows to run the test suite in multiple platforms,
especially the ones without Python 3.7.

issue: #185