### PR TITLE
Some improvements to the Python test suite

### DIFF
--- a/test/e2e/TestEnv.py
+++ b/test/e2e/TestEnv.py
@@ -168,7 +168,7 @@ class TestEnv:
         args = [cls.APACHECTL, "-d", cls.WEBROOT, "-k", cmd]
         print("execute: %s" % " ".join(args))
         cls.apachectl_stderr = ""
-        p = subprocess.run(args, stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+        p = subprocess.run(args, stderr=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
         sys.stderr.write(p.stderr)
         rv = p.returncode
         if rv == 0:

--- a/test/e2e/TestEnv.py
+++ b/test/e2e/TestEnv.py
@@ -18,7 +18,7 @@ import requests
 from datetime import datetime
 from datetime import tzinfo
 from datetime import timedelta
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 from shutil import copyfile
 from urllib.parse import urlparse
 from TestNghttp import Nghttp
@@ -31,7 +31,7 @@ class TestEnv:
     def init( cls ) :
         if TestEnv.initialized:
             return
-        cls.config = SafeConfigParser()
+        cls.config = ConfigParser()
         cls.config.read('config.ini')
         
         cls.PREFIX      = cls.config.get('global', 'prefix')

--- a/test/e2e/test_003_get.py
+++ b/test/e2e/test_003_get.py
@@ -34,19 +34,21 @@ class TestStore:
     # check SSL environment variables from CGI script
     def test_003_01(self):
         url = TestEnv.mkurl("https", "cgi", "/hello.py")
-        r = TestEnv.curl_get(url, 5)
+        r = TestEnv.curl_get(url, 5, ["--tlsv1.2"])
         assert 200 == r["response"]["status"]
         assert "HTTP/2.0" == r["response"]["json"]["protocol"]
         assert "on" == r["response"]["json"]["https"]
-        assert "TLSv1.2" == r["response"]["json"]["ssl_protocol"]
+        tls_version = r["response"]["json"]["ssl_protocol"]
+        assert tls_version in ["TLSv1.2", "TLSv1.3"]
         assert "on" == r["response"]["json"]["h2"]
         assert "off" == r["response"]["json"]["h2push"]
 
-        r = TestEnv.curl_get(url, 5, [ "--http1.1" ])
+        r = TestEnv.curl_get(url, 5, [ "--http1.1", "--tlsv1.2"])
         assert 200 == r["response"]["status"]
         assert "HTTP/1.1" == r["response"]["json"]["protocol"]
         assert "on" == r["response"]["json"]["https"]
-        assert "TLSv1.2" == r["response"]["json"]["ssl_protocol"]
+        tls_version = r["response"]["json"]["ssl_protocol"]
+        assert tls_version in ["TLSv1.2", "TLSv1.3"]
         assert "" == r["response"]["json"]["h2"]
         assert "" == r["response"]["json"]["h2push"]
 


### PR DESCRIPTION
- test_003_get.py
  * force curl to use tls1.2+
  * allow TLS 1.3 as result
- TestEnv.py
  * shut off a warning for configparser.SafeConfigParser
  * replace subprocess' text=true with universal_newlines=True