### PR TITLE
Remove unused leave_ctx from h2_beam_lock structure and adjust callers.

### DIFF
--- a/mod_http2/h2_bucket_beam.c
+++ b/mod_http2/h2_bucket_beam.c
@@ -196,9 +196,8 @@ static apr_bucket *h2_beam_bucket(h2_bucket_beam *beam,
  * bucket beam that can transport buckets across threads
  ******************************************************************************/
 
-static void mutex_leave(void *ctx, apr_thread_mutex_t *lock)
+static void mutex_leave(apr_thread_mutex_t *lock)
 {
-    (void)ctx;
     apr_thread_mutex_unlock(lock);
 }
 
@@ -219,7 +218,7 @@ static void leave_yellow(h2_bucket_beam *beam, h2_beam_lock *pbl)
 {
     (void)beam;
     if (pbl->leave) {
-        pbl->leave(pbl->leave_ctx, pbl->mutex);
+        pbl->leave(pbl->mutex);
     }
 }
 

--- a/mod_http2/h2_bucket_beam.h
+++ b/mod_http2/h2_bucket_beam.h
@@ -126,12 +126,11 @@ typedef struct {
  * buffers until the transmission is complete. Star gates use a similar trick.
  */
 
-typedef void h2_beam_mutex_leave(void *ctx,  struct apr_thread_mutex_t *lock);
+typedef void h2_beam_mutex_leave(struct apr_thread_mutex_t *lock);
 
 typedef struct {
     apr_thread_mutex_t *mutex;
     h2_beam_mutex_leave *leave;
-    void *leave_ctx;
 } h2_beam_lock;
 
 typedef struct h2_bucket_beam h2_bucket_beam;


### PR DESCRIPTION
Not sure why but I'm seeing gcc 10 warnings on s390x (only) for this.
```
h2_bucket_beam.c: In function 'h2_beam_abort':
h2_bucket_beam.c:222:9: error: 'bl.leave_ctx' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  222 |         pbl->leave(pbl->leave_ctx, pbl->mutex);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
h2_bucket_beam.c:710:18: note: 'bl.leave_ctx' was declared here
  710 |     h2_beam_lock bl;
      |                  ^~
h2_bucket_beam.c: In function 'h2_beam_close':
h2_bucket_beam.c:222:9: error: 'bl.leave_ctx' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  222 |         pbl->leave(pbl->leave_ctx, pbl->mutex);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```