### PR TITLE
Fix gcc warning for H2_STRM_LOG() use in h2_session_push.

### DIFF
--- a/mod_http2/h2_session.c
+++ b/mod_http2/h2_session.c
@@ -1179,7 +1179,7 @@ struct h2_stream *h2_session_push(h2_session *session, h2_stream *is,
     stream = h2_session_open_stream(session, nid, is->id);
     if (!stream) {
         ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, session->c, 
-                      H2_STRM_LOG(APLOGNO(03077), stream, 
+                      H2_STRM_LOG(APLOGNO(03077), is,
                       "failed to create stream obj %d"), nid);
         /* kill the push_promise */
         nghttp2_submit_rst_stream(session->ngh2, NGHTTP2_FLAG_NONE, nid,


### PR DESCRIPTION
After `h2_session_open_stream(session, nid, is->id)` returns NULL, don't reference it via H2_STRM_LOG(), using "is" instead is appropriate I assume?

```
In file included from h2_session.c:28:
h2_session.c: In function ‘h2_session_push’:
/usr/include/httpd/http_log.h:498:23: warning: null pointer dereference [-Wnull-dereference]
  498 | #define ap_log_cerror ap_log_cerror_
h2_session.c:1181:9: note: in expansion of macro ‘ap_log_cerror’
 1181 |         ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, session->c,
      |         ^~~~~~~~~~~~~
In file included from h2_session.c:45:
h2_stream.h:309:35: warning: null pointer dereference [-Wnull-dereference]
  309 |     "h2_stream(%ld-%d,%s): "msg, s->session->id, s->id, h2_stream_state_str(s)
h2_stream.h:311:49: note: in expansion of macro ‘H2_STRM_MSG’
  311 | #define H2_STRM_LOG(aplogno, s, msg)    aplogno H2_STRM_MSG(s, msg)
      |                                                 ^~~~~~~~~~~
h2_session.c:1182:23: note: in expansion of macro ‘H2_STRM_LOG’
 1182 |                       H2_STRM_LOG(APLOGNO(03077), stream,
      |                       ^~~~~~~~~~~
```