### PR TITLE
In case, nghttp is ignoring -a param, skip tests.

### DIFF
--- a/test/e2e/TestEnv.py
+++ b/test/e2e/TestEnv.py
@@ -76,6 +76,22 @@ class TestEnv:
         cls.init()
         return cls.NGHTTP != ""
 
+    @classmethod
+    def has_nghttp_get_assets ( cls ) :
+        cls.init()
+
+        if not TestEnv.has_nghttp():
+            return False
+
+        args = [cls.NGHTTP, "-a"]
+        p = subprocess.run(args, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        rv = p.returncode
+
+        if rv != 0:
+           return False
+
+        return p.stderr == ""
+
 
 ###################################################################################################
 # path construction

--- a/test/e2e/test_006_assets.py
+++ b/test/e2e/test_006_assets.py
@@ -31,7 +31,7 @@ class TestStore:
         print("teardown_method: %s" % method.__name__)
     
     # single page without any assets
-    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available")
+    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available or nghttp ignores -a option")
     def test_006_01(self):
         url = TestEnv.mkurl("https", "test1", "/001.html")
         r = TestEnv.nghttp().assets(url,  options=[ "-Haccept-encoding: none" ])
@@ -42,7 +42,7 @@ class TestStore:
         ]
 
     # single image without any assets
-    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available")
+    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available or nghttp ignores -a option")
     def test_006_02(self):
         url = TestEnv.mkurl("https", "test1", "/002.jpg")
         r = TestEnv.nghttp().assets(url,  options=[ "-Haccept-encoding: none" ])
@@ -53,7 +53,7 @@ class TestStore:
         ]
         
     # gophertiles, yea!
-    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available")
+    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available or nghttp ignores -a option")
     def test_006_03(self):
         url = TestEnv.mkurl("https", "test1", "/004.html")
         r = TestEnv.nghttp().assets(url, options=[ "-Haccept-encoding: none" ])
@@ -244,7 +244,7 @@ class TestStore:
         ]            
             
     # page with js and css
-    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available")
+    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available or nghttp ignores -a option")
     def test_006_04(self):
         url = TestEnv.mkurl("https", "test1", "/006.html")
         r = TestEnv.nghttp().assets(url, options=[ "-Haccept-encoding: none" ])
@@ -257,7 +257,7 @@ class TestStore:
         ]
 
     # page with image, try different window size
-    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available")
+    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available or nghttp ignores -a option")
     def test_006_05(self):
         url = TestEnv.mkurl("https", "test1", "/003.html")
         r = TestEnv.nghttp().assets(url, options=[ "--window-bits=24", "-Haccept-encoding: none" ])

--- a/test/e2e/test_006_assets.py
+++ b/test/e2e/test_006_assets.py
@@ -31,7 +31,7 @@ class TestStore:
         print("teardown_method: %s" % method.__name__)
     
     # single page without any assets
-    @pytest.mark.skipif(not TestEnv.has_nghttp(), reason="no nghttp command available")
+    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available")
     def test_006_01(self):
         url = TestEnv.mkurl("https", "test1", "/001.html")
         r = TestEnv.nghttp().assets(url,  options=[ "-Haccept-encoding: none" ])
@@ -42,7 +42,7 @@ class TestStore:
         ]
 
     # single image without any assets
-    @pytest.mark.skipif(not TestEnv.has_nghttp(), reason="no nghttp command available")
+    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available")
     def test_006_02(self):
         url = TestEnv.mkurl("https", "test1", "/002.jpg")
         r = TestEnv.nghttp().assets(url,  options=[ "-Haccept-encoding: none" ])
@@ -53,7 +53,7 @@ class TestStore:
         ]
         
     # gophertiles, yea!
-    @pytest.mark.skipif(not TestEnv.has_nghttp(), reason="no nghttp command available")
+    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available")
     def test_006_03(self):
         url = TestEnv.mkurl("https", "test1", "/004.html")
         r = TestEnv.nghttp().assets(url, options=[ "-Haccept-encoding: none" ])
@@ -244,7 +244,7 @@ class TestStore:
         ]            
             
     # page with js and css
-    @pytest.mark.skipif(not TestEnv.has_nghttp(), reason="no nghttp command available")
+    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available")
     def test_006_04(self):
         url = TestEnv.mkurl("https", "test1", "/006.html")
         r = TestEnv.nghttp().assets(url, options=[ "-Haccept-encoding: none" ])
@@ -257,7 +257,7 @@ class TestStore:
         ]
 
     # page with image, try different window size
-    @pytest.mark.skipif(not TestEnv.has_nghttp(), reason="no nghttp command available")
+    @pytest.mark.skipif(not TestEnv.has_nghttp_get_assets(), reason="no nghttp command available")
     def test_006_05(self):
         url = TestEnv.mkurl("https", "test1", "/003.html")
         r = TestEnv.nghttp().assets(url, options=[ "--window-bits=24", "-Haccept-encoding: none" ])


### PR DESCRIPTION
if there is some output on stderr when nghttp -a is executed, skip tests where -a param is used.