### PR TITLE
Switch to using OpenSSL EVP_* API to avoid deprecation warnings with OpenSSL 3.0.

### DIFF
--- a/mod_http2/h2_push.c
+++ b/mod_http2/h2_push.c
@@ -23,7 +23,7 @@
 #include <apr_time.h>
 
 #ifdef H2_OPENSSL
-#include <openssl/sha.h>
+#include <openssl/evp.h>
 #endif
 
 #include <httpd.h>
@@ -472,27 +472,32 @@ typedef struct h2_push_diary_entry {
 
 
 #ifdef H2_OPENSSL
-static void sha256_update(SHA256_CTX *ctx, const char *s)
+static void sha256_update(EVP_MD_CTX *ctx, const char *s)
 {
-    SHA256_Update(ctx, s, strlen(s));
+    EVP_DigestUpdate(ctx, s, strlen(s));
 }
 
 static void calc_sha256_hash(h2_push_diary *diary, apr_uint64_t *phash, h2_push *push) 
 {
-    SHA256_CTX sha256;
+    EVP_MD_CTX *md;
     apr_uint64_t val;
-    unsigned char hash[SHA256_DIGEST_LENGTH];
+    unsigned char hash[EVP_MAX_MD_SIZE];
+    unsigned len;
     int i;
-    
-    SHA256_Init(&sha256);
-    sha256_update(&sha256, push->req->scheme);
-    sha256_update(&sha256, "://");
-    sha256_update(&sha256, push->req->authority);
-    sha256_update(&sha256, push->req->path);
-    SHA256_Final(hash, &sha256);
+
+    md = EVP_MD_CTX_create();
+    ap_assert(md != NULL);
+
+    i = EVP_DigestInit_ex(md, EVP_sha256(), NULL);
+    ap_assert(i == 1);
+    sha256_update(md, push->req->scheme);
+    sha256_update(md, "://");
+    sha256_update(md, push->req->authority);
+    sha256_update(md, push->req->path);
+    EVP_DigestFinal(md, hash, &len);
 
     val = 0;
-    for (i = 0; i != sizeof(val); ++i)
+    for (i = 0; i != len; ++i)
         val = val * 256 + hash[i];
     *phash = val >> (64 - diary->mask_bits);
 }


### PR DESCRIPTION
Not sure if the test suite is exercising this code directly, so may be untested.  FWIW I get the same four failures running "make test" against httpd trunk on Fedora 34 with and without this patch.

```
============================================== short test summary info ==============================================
FAILED test_101_ssl_reneg.py::TestStore::test_101_02 - assert 0 != 0
FAILED test_101_ssl_reneg.py::TestStore::test_101_11 - assert 0 != 0
FAILED test_105_timeout.py::TestStore::test_105_01 - assert False
FAILED test_105_timeout.py::TestStore::test_105_02 - assert False
```