### PR TITLE
Also distribute test/mod_h2test/Makefile.in, so people don't need to …

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,7 @@ DIST_SUBDIRS    = mod_http2
 ACLOCAL_AMFLAGS = -I m4
 
 EXTRA_DIST     = test/e2e test/unit test/Makefile.in test/Makefile.am \
+	test/mod_h2test/Makefile.in \
 	test/mod_h2test/Makefile.am \
 	test/mod_h2test/mod_h2test.c \
 	test/mod_h2test/mod_h2test.h


### PR DESCRIPTION
…run autoreconf on distributed tarball.