### PR TITLE
Improvement on stream input handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+ * Delaying input setup of a stream just before processing starts. This allows
+   any EOS indicator arriving from the client before that to take effect.
+   Without knowing that a stream has no input, internal processing has to
+   simulate chunked encoding. This is not wrong, but somewhat more expensive
+   and mod_security has been reported to be allergic to seeing 'chunked'
+   on some requests. See <https://bz.apache.org/bugzilla/show_bug.cgi?id=66282>.
  * mod_proxy_http2: fixed #235 by no longer forwarding 'Host:' header when
    request ':authority' is known. Improved test case that did not catch that
    the previous 'fix' was incorrect.

--- a/mod_http2/h2.h
+++ b/mod_http2/h2.h
@@ -156,7 +156,6 @@ struct h2_request {
     apr_table_t *headers;
 
     apr_time_t request_time;
-    unsigned int chunked : 1;   /* iff request body needs to be forwarded as chunked */
     apr_off_t raw_bytes;        /* RAW network bytes that generated this request - if known. */
     int http_status;            /* Store a possible HTTP status code that gets
                                  * defined before creating the dummy HTTP/1.1

--- a/mod_http2/h2_c2_filter.c
+++ b/mod_http2/h2_c2_filter.c
@@ -635,7 +635,7 @@ apr_status_t h2_c2_filter_catch_h1_out(ap_filter_t* f, apr_bucket_brigade* bb)
                  */
                 int result = ap_map_http_request_error(conn_ctx->last_err,
                                                        HTTP_INTERNAL_SERVER_ERROR);
-                request_rec *r = h2_create_request_rec(conn_ctx->request, f->c);
+                request_rec *r = h2_create_request_rec(conn_ctx->request, f->c, 1);
                 ap_die((result >= 400)? result : HTTP_INTERNAL_SERVER_ERROR, r);
                 b = ap_bucket_eor_create(f->c->bucket_alloc, r);
                 APR_BRIGADE_INSERT_TAIL(bb, b);
@@ -918,7 +918,7 @@ apr_status_t h2_c2_filter_request_in(ap_filter_t* f,
                   "readbytes=%ld, exp=%d",
                   conn_ctx->id, conn_ctx->stream_id, mode, block,
                   (long)readbytes, r->expecting_100);
-    if (!conn_ctx->request->chunked) {
+    if (!conn_ctx->input_chunked) {
         status = ap_get_brigade(f->next, bb, mode, block, readbytes);
         /* pipe data through, just take care of trailers */
         for (b = APR_BRIGADE_FIRST(bb);

--- a/mod_http2/h2_conn_ctx.h
+++ b/mod_http2/h2_conn_ctx.h
@@ -53,6 +53,7 @@ struct h2_conn_ctx_t {
     const struct h2_request *request; /* c2: the request to process */
     struct h2_bucket_beam *beam_out; /* c2: data out, created from req_pool */
     struct h2_bucket_beam *beam_in;  /* c2: data in or NULL, borrowed from request stream */
+    unsigned int input_chunked;      /* c2: if input needs HTTP/1.1 chunking applied */
 
     apr_file_t *pipe_in[2];          /* c2: input produced notification pipe */
     apr_pollfd_t pfd;                /* c1: poll socket input, c2: NUL */

--- a/mod_http2/h2_push.c
+++ b/mod_http2/h2_push.c
@@ -351,7 +351,7 @@ static int add_push(link_ctx *ctx)
                 req = h2_request_create(0, ctx->pool, method, ctx->req->scheme,
                                         ctx->req->authority, path, headers);
                 /* atm, we do not push on pushes */
-                h2_request_end_headers(req, ctx->pool, 1, 0);
+                h2_request_end_headers(req, ctx->pool, 0);
                 push->req = req;
                 if (has_param(ctx, "critical")) {
                     h2_priority *prio = apr_pcalloc(ctx->pool, sizeof(*prio));

--- a/mod_http2/h2_request.h
+++ b/mod_http2/h2_request.h
@@ -35,7 +35,8 @@ apr_status_t h2_request_add_trailer(h2_request *req, apr_pool_t *pool,
                                     const char *name, size_t nlen,
                                     const char *value, size_t vlen);
 
-apr_status_t h2_request_end_headers(h2_request *req, apr_pool_t *pool, int eos, size_t raw_bytes);
+apr_status_t h2_request_end_headers(h2_request *req, apr_pool_t *pool,
+                                     size_t raw_bytes);
 
 h2_request *h2_request_clone(apr_pool_t *p, const h2_request *src);
 
@@ -45,9 +46,11 @@ h2_request *h2_request_clone(apr_pool_t *p, const h2_request *src);
  *
  * @param req the h2 request to process
  * @param conn the connection to process the request on
+ * @param no_body != 0 iff the request is known to have no body
  * @return the request_rec representing the request
  */
-request_rec *h2_create_request_rec(const h2_request *req, conn_rec *conn);
+request_rec *h2_create_request_rec(const h2_request *req, conn_rec *conn,
+                                   int no_body);
 
 #if AP_HAS_RESPONSE_BUCKETS
 apr_bucket *h2_request_create_bucket(const h2_request *req, request_rec *r);

--- a/mod_http2/h2_stream.h
+++ b/mod_http2/h2_stream.h
@@ -138,9 +138,9 @@ h2_stream *h2_stream_create(int id, apr_pool_t *pool,
 void h2_stream_destroy(h2_stream *stream);
 
 /**
- * Setup the input for the stream.
+ * Perform any late initialization before stream starts processing.
  */
-apr_status_t h2_stream_setup_input(h2_stream *stream);
+apr_status_t h2_stream_prepare_processing(h2_stream *stream);
 
 /*
  * Set a new monitor for this stream, replacing any existing one. Can


### PR DESCRIPTION
 * Delaying input setup of a stream just before processing starts. This allows any EOS indicator arriving from the client before that to take effect. Without knowing that a stream has no input, internal processing has to simulate chunked encoding. This is not wrong, but somewhat more expensive and mod_security has been reported to be allergic to seeing 'chunked' on some requests. See <https://bz.apache.org/bugzilla/show_bug.cgi?id=66282>.