### PR TITLE
H2MaxDataFrameLen added incl test cases.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+ * New directive 'H2MaxDataFrameLen n' to limit the maximum amount of response
+   body bytes put into a single HTTP/2 DATA frame. Setting this to 0 places
+   no limit (but the max size allowed by the protocol is observed).
+   The module, by default, tries to use the maximum size possible, which is
+   somewhat around 16KB.
+   This sets the maximum. When less response data is availble, smaller frames
+   will be sent.
+
 v2.0.12
 --------------------------------------------------------------------------------
  * client resets of HTTP/2 streams led to unwanted 500 errors

--- a/mod_http2/h2_config.h
+++ b/mod_http2/h2_config.h
@@ -43,6 +43,7 @@ typedef enum {
     H2_CONF_PADDING_ALWAYS,
     H2_CONF_OUTPUT_BUFFER,
     H2_CONF_STREAM_TIMEOUT,
+    H2_CONF_MAX_DATA_FRAME_LEN,
 } h2_config_var_t;
 
 struct apr_hash_t;

--- a/mod_http2/h2_session.c
+++ b/mod_http2/h2_session.c
@@ -902,7 +902,8 @@ apr_status_t h2_session_create(h2_session **psession, conn_rec *c, request_rec *
     
     session->max_stream_count = h2_config_sgeti(s, H2_CONF_MAX_STREAMS);
     session->max_stream_mem = h2_config_sgeti(s, H2_CONF_STREAM_MAX_MEM);
-    
+    session->max_data_frame_len = h2_config_sgeti(s, H2_CONF_MAX_DATA_FRAME_LEN);
+
     session->out_c1_blocked = h2_iq_create(session->pool, (int)session->max_stream_count);
     session->ready_to_process = h2_iq_create(session->pool, (int)session->max_stream_count);
 
@@ -983,13 +984,15 @@ apr_status_t h2_session_create(h2_session **psession, conn_rec *c, request_rec *
                       H2_SSSN_LOG(APLOGNO(03200), session, 
                                   "created, max_streams=%d, stream_mem=%d, "
                                   "workers_limit=%d, workers_max=%d, "
-                                  "push_diary(type=%d,N=%d)"),
+                                  "push_diary(type=%d,N=%d), "
+                                  "max_data_frame_len=%d"),
                       (int)session->max_stream_count, 
                       (int)session->max_stream_mem,
                       session->mplx->processing_limit,
                       session->mplx->processing_max,
                       session->push_diary->dtype, 
-                      (int)session->push_diary->N);
+                      (int)session->push_diary->N,
+                      (int)session->max_data_frame_len);
     }
     
     apr_pool_pre_cleanup_register(pool, c, session_pool_cleanup);

--- a/mod_http2/h2_session.h
+++ b/mod_http2/h2_session.h
@@ -103,7 +103,8 @@ typedef struct h2_session {
     
     apr_size_t max_stream_count;    /* max number of open streams */
     apr_size_t max_stream_mem;      /* max buffer memory for a single stream */
-    
+    apr_size_t max_data_frame_len;  /* max amount of bytes for a single DATA frame */
+
     apr_size_t idle_frames;         /* number of rcvd frames that kept session in idle state */
     apr_interval_time_t idle_delay; /* Time we delay processing rcvd frames in idle state */
     

--- a/mod_http2/h2_stream.c
+++ b/mod_http2/h2_stream.c
@@ -1361,6 +1361,11 @@ static ssize_t stream_data_cb(nghttp2_session *ng2s,
             length = chunk_len;
         }
     }
+    /* We allow configurable max DATA frame length. */
+    if (stream->session->max_data_frame_len > 0
+        && length > stream->session->max_data_frame_len) {
+      length = stream->session->max_data_frame_len;
+    }
 
     /* How much data do we have in our buffers that we can write?
      * if not enough, receive more. */

--- a/test/modules/http2/test_107_frame_lengths.py
+++ b/test/modules/http2/test_107_frame_lengths.py
@@ -1,0 +1,51 @@
+import os
+import pytest
+
+from .env import H2Conf, H2TestEnv
+
+
+def mk_text_file(fpath: str, lines: int):
+    t110 = ""
+    for _ in range(11):
+        t110 += "0123456789"
+    with open(fpath, "w") as fd:
+        for i in range(lines):
+            fd.write("{0:015d}: ".format(i))  # total 128 bytes per line
+            fd.write(t110)
+            fd.write("\n")
+
+
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+class TestFrameLengths:
+
+    URI_PATHS = []
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env):
+        docs_a = os.path.join(env.server_docs_dir, "cgi/files")
+        for fsize in [10, 100]:
+            fname = f'0-{fsize}k.txt'
+            mk_text_file(os.path.join(docs_a, fname), 8 * fsize)
+            self.URI_PATHS.append(f"/files/{fname}")
+
+    @pytest.mark.parametrize("data_frame_len", [
+        99, 1024, 8192
+    ])
+    def test_h2_107_01(self, env, data_frame_len):
+        conf = H2Conf(env, extras={
+            f'cgi.{env.http_tld}': [
+                f'H2MaxDataFrameLen {data_frame_len}',
+            ]
+        })
+        conf.add_vhost_cgi()
+        conf.install()
+        assert env.apache_restart() == 0
+        for p in self.URI_PATHS:
+            url = env.mkurl("https", "cgi", p)
+            r = env.nghttp().get(url, options=[
+                '--header=Accept-Encoding: none',
+            ])
+            assert r.response["status"] == 200
+            assert len(r.results["data_lengths"]) > 0, f'{r}'
+            too_large = [ x for x in r.results["data_lengths"] if x > data_frame_len]
+            assert len(too_large) == 0, f'{p}: {r.results["data_lengths"]}'

--- a/test/pyhttpd/nghttp.py
+++ b/test/pyhttpd/nghttp.py
@@ -37,6 +37,7 @@ class Nghttp:
                         "id": sid,
                         "body": b''
                     },
+                    "data_lengths": [],
                     "paddings": [],
                     "promises": []
             }
@@ -131,12 +132,13 @@ class Nghttp:
                 s = self.get_stream(streams, m.group(3))
                 blen = int(m.group(2))
                 if s:
-                    print("stream %d: %d DATA bytes added" % (s["id"], blen))
+                    print(f'stream {s["id"]}: {blen} DATA bytes added via "{l}"')
                     padlen = 0
                     if len(lines) > lidx + 2:
                         mpad = re.match(r' +\(padlen=(\d+)\)', lines[lidx+2])
                         if mpad: 
                             padlen = int(mpad.group(1))
+                    s["data_lengths"].append(blen)
                     s["paddings"].append(padlen)
                     blen -= padlen
                     s["response"]["body"] += body[-blen:].encode()
@@ -196,6 +198,7 @@ class Nghttp:
         if main_stream in streams:
             output["response"] = streams[main_stream]["response"]
             output["paddings"] = streams[main_stream]["paddings"]
+            output["data_lengths"] = streams[main_stream]["data_lengths"]
         return output
 
     def _raw(self, url, timeout, options):


### PR DESCRIPTION
 * New directive 'H2MaxDataFrameLen n' to limit the maximum amount of response body bytes put into a single HTTP/2 DATA frame. Setting this to 0 places no limit (but the max size allowed by the protocol is observed). The module, by default, tries to use the maximum size possible, which is somewhat around 16KB. This sets the maximum. When less response data is availble, smaller frames will be sent.