### PR TITLE
fix for logio reported bytes sent

### DIFF
--- a/mod_http2/h2_bucket_beam.c
+++ b/mod_http2/h2_bucket_beam.c
@@ -24,6 +24,7 @@
 
 #include <httpd.h>
 #include <http_protocol.h>
+#include <http_request.h>
 #include <http_log.h>
 
 #include "h2_private.h"
@@ -156,6 +157,23 @@ static void purge_consumed_buckets(h2_bucket_beam *beam)
      * from sender thread only */
     while (!H2_BLIST_EMPTY(&beam->buckets_consumed)) {
         b = H2_BLIST_FIRST(&beam->buckets_consumed);
+        if(AP_BUCKET_IS_EOR(b)) {
+          APR_BUCKET_REMOVE(b);
+          H2_BLIST_INSERT_TAIL(&beam->buckets_eor, b);
+        }
+        else {
+          apr_bucket_delete(b);
+        }
+    }
+}
+
+static void purge_eor_buckets(h2_bucket_beam *beam)
+{
+    apr_bucket *b;
+    /* delete all sender buckets in purge brigade, needs to be called
+     * from sender thread only */
+    while (!H2_BLIST_EMPTY(&beam->buckets_eor)) {
+        b = H2_BLIST_FIRST(&beam->buckets_eor);
         apr_bucket_delete(b);
     }
 }
@@ -263,6 +281,7 @@ static apr_status_t beam_cleanup(void *data)
 {
     h2_bucket_beam *beam = data;
     beam_shutdown(beam, APR_SHUTDOWN_READWRITE);
+    purge_eor_buckets(beam);
     beam->pool = NULL; /* the pool is clearing now */
     return APR_SUCCESS;
 }
@@ -295,6 +314,7 @@ apr_status_t h2_beam_create(h2_bucket_beam **pbeam, conn_rec *from,
 
     H2_BLIST_INIT(&beam->buckets_to_send);
     H2_BLIST_INIT(&beam->buckets_consumed);
+    H2_BLIST_INIT(&beam->buckets_eor);
     beam->tx_mem_limits = 1;
     beam->max_buf_size = max_buf_size;
     beam->timeout = timeout;

--- a/mod_http2/h2_bucket_beam.h
+++ b/mod_http2/h2_bucket_beam.h
@@ -48,6 +48,7 @@ struct h2_bucket_beam {
     apr_pool_t *pool;
     h2_blist buckets_to_send;
     h2_blist buckets_consumed;
+    h2_blist buckets_eor;
 
     apr_size_t max_buf_size;
     apr_interval_time_t timeout;

--- a/mod_http2/h2_c2.c
+++ b/mod_http2/h2_c2.c
@@ -133,10 +133,22 @@ apr_status_t h2_c2_child_init(apr_pool_t *pool, server_rec *s)
                              APR_PROTO_TCP, pool);
 }
 
+static void h2_c2_log_io(conn_rec *c2, apr_off_t bytes_sent)
+{
+    if (bytes_sent && h2_c_logio_add_bytes_out) {
+        h2_c_logio_add_bytes_out(c2, bytes_sent);
+    }
+}
+
 void h2_c2_destroy(conn_rec *c2)
 {
+    h2_conn_ctx_t *conn_ctx = h2_conn_ctx_get(c2);
+
     ap_log_cerror(APLOG_MARK, APLOG_TRACE3, 0, c2,
                   "h2_c2(%s): destroy", c2->log_id);
+    if(!c2->aborted && conn_ctx && conn_ctx->bytes_sent) {
+      h2_c2_log_io(c2, conn_ctx->bytes_sent);
+    }
     apr_pool_destroy(c2->pool);
 }
 
@@ -146,6 +158,10 @@ void h2_c2_abort(conn_rec *c2, conn_rec *from)
 
     AP_DEBUG_ASSERT(conn_ctx);
     AP_DEBUG_ASSERT(conn_ctx->stream_id);
+    if(!c2->aborted && conn_ctx->bytes_sent) {
+      h2_c2_log_io(c2, conn_ctx->bytes_sent);
+    }
+
     if (conn_ctx->beam_in) {
         h2_beam_abort(conn_ctx->beam_in, from);
     }
@@ -326,41 +342,12 @@ receive:
 
 static apr_status_t beam_out(conn_rec *c2, h2_conn_ctx_t *conn_ctx, apr_bucket_brigade* bb)
 {
-    apr_off_t written, header_len = 0;
+    apr_off_t written = 0;
     apr_status_t rv;
 
-    if (h2_c_logio_add_bytes_out) {
-        /* mod_logio wants to report the number of bytes  written in a
-         * response, including header and footer fields. Since h2 converts
-         * those during c1 processing into the HPACKed h2 HEADER frames,
-         * we need to give mod_logio something here and count just the
-         * raw lengths of all headers in the buckets. */
-        apr_bucket *b;
-        for (b = APR_BRIGADE_FIRST(bb);
-             b != APR_BRIGADE_SENTINEL(bb);
-             b = APR_BUCKET_NEXT(b)) {
-#if AP_HAS_RESPONSE_BUCKETS
-            if (AP_BUCKET_IS_RESPONSE(b)) {
-                header_len += (apr_off_t)response_length_estimate(b->data);
-            }
-            if (AP_BUCKET_IS_HEADERS(b)) {
-                header_len += (apr_off_t)headers_length_estimate(b->data);
-            }
-#else
-            if (H2_BUCKET_IS_HEADERS(b)) {
-                header_len += (apr_off_t)h2_bucket_headers_headers_length(b);
-            }
-#endif /* AP_HAS_RESPONSE_BUCKETS */
-        }
-    }
-
     rv = h2_beam_send(conn_ctx->beam_out, c2, bb, APR_BLOCK_READ, &written);
-
     if (APR_STATUS_IS_EAGAIN(rv)) {
         rv = APR_SUCCESS;
-    }
-    if (written && h2_c_logio_add_bytes_out) {
-        h2_c_logio_add_bytes_out(c2, written + header_len);
     }
     return rv;
 }

--- a/mod_http2/h2_conn_ctx.h
+++ b/mod_http2/h2_conn_ctx.h
@@ -61,6 +61,7 @@ struct h2_conn_ctx_t {
     int has_final_response;          /* final HTTP response passed on out */
     apr_status_t last_err;           /* APR_SUCCES or last error encountered in filters */
 
+    apr_off_t bytes_sent;            /* c2: bytes acutaly sent via c1 */
     /* atomic */ apr_uint32_t started; /* c2: processing was started */
     apr_time_t started_at;           /* c2: when processing started */
     /* atomic */ apr_uint32_t done;  /* c2: processing has finished */

--- a/mod_http2/h2_mplx.c
+++ b/mod_http2/h2_mplx.c
@@ -441,6 +441,8 @@ static int m_stream_cancel_iter(void *ctx, void *val) {
     return 0;
 }
 
+static void c1_purge_streams(h2_mplx *m);
+
 void h2_mplx_c1_destroy(h2_mplx *m)
 {
     apr_status_t status;
@@ -509,7 +511,9 @@ void h2_mplx_c1_destroy(h2_mplx *m)
                       h2_ihash_count(m->shold));
         h2_ihash_iter(m->shold, m_unexpected_stream_iter, m);
     }
-    
+
+    c1_purge_streams(m);
+
     m->c1->aborted = old_aborted;
     H2_MPLX_LEAVE(m);
 

--- a/mod_http2/h2_stream.c
+++ b/mod_http2/h2_stream.c
@@ -435,6 +435,12 @@ apr_status_t h2_stream_send_frame(h2_stream *stream, int ftype, int flags, size_
 
     ++stream->out_frames;
     stream->out_frame_octets += frame_len;
+    if(stream->c2) {
+      h2_conn_ctx_t *conn_ctx = h2_conn_ctx_get(stream->c2);
+      if(conn_ctx)
+        conn_ctx->bytes_sent = stream->out_frame_octets;
+    }
+
     switch (ftype) {
         case NGHTTP2_DATA:
             eos = (flags & NGHTTP2_FLAG_END_STREAM);

--- a/test/modules/http2/test_008_ranges.py
+++ b/test/modules/http2/test_008_ranges.py
@@ -1,0 +1,56 @@
+import os
+import pytest
+
+from .env import H2Conf, H2TestEnv
+
+
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+class TestGet:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env):
+        destdir = os.path.join(env.gen_dir, 'apache/htdocs/test1')
+        env.make_data_file(indir=destdir, fname="data-100m", fsize=100*1024*1024)
+        conf = H2Conf(env=env, extras={
+            'base': [
+                'LogFormat "{\\"request\\": \\"%r\\", \\"status\\": \\"%>s\\", \\"recv\\": %I, \\"sent\\": %O, \\"ms\\": %D}" combined',
+            ]
+        })
+        conf.add_vhost_cgi(
+            proxy_self=True, h2proxy_self=True
+        ).add_vhost_test1(
+            proxy_self=True, h2proxy_self=True
+        )
+        conf.install()
+        assert env.apache_restart() == 0
+
+    def test_h2_008_01(self, env, repeat):
+        path = '/002.jpg'
+        url = env.mkurl("https", "test1", path)
+        r = env.curl_get(url, 5)
+        assert r.response["status"] == 200
+        assert "HTTP/2" == r.response["protocol"]
+        h = r.response["header"]
+        assert "accept-ranges" in h
+        assert "bytes" == h["accept-ranges"]
+        assert "content-length" in h
+        clen = h["content-length"]
+        assert int(clen) == 90364
+        # get the first 1024 bytes of the resource, 206 status, but content-length as original
+        for i in range(10):
+            r = env.curl_get(url, 5, options=["-H", "range: bytes=0-1023"])
+            if r.response["status"] != 503:
+                break
+        assert 206 == r.response["status"]
+        assert "HTTP/2" == r.response["protocol"]
+        assert 1024 == len(r.response["body"])
+        assert "content-length" in h
+        assert clen == h["content-length"]
+
+    def test_h2_008_02(self, env, repeat):
+        path = '/data-100m'
+        url = env.mkurl("https", "test1", path)
+        r = env.curl_get(url, 5, options=[
+            '--limit-rate', '2k', '-m', '2'
+        ])
+        assert r.exit_code != 0, f'{r}'

--- a/test/pyhttpd/env.py
+++ b/test/pyhttpd/env.py
@@ -237,6 +237,8 @@ class HttpdTestEnv:
         if HttpdTestEnv.LIBEXEC_DIR is None:
             HttpdTestEnv.LIBEXEC_DIR = self._libexec_dir = self.get_apxs_var('LIBEXECDIR')
         self._curl = self.config.get('global', 'curl_bin')
+        if 'CURL' in os.environ:
+            self._curl = os.environ['CURL']
         self._nghttp = self.config.get('global', 'nghttp')
         if self._nghttp is None:
             self._nghttp = 'nghttp'
@@ -837,3 +839,18 @@ class HttpdTestEnv:
                 }
             run.add_results({"h2load": stats})
         return run
+
+    def make_data_file(self, indir: str, fname: str, fsize: int) -> str:
+        fpath = os.path.join(indir, fname)
+        s10 = "0123456789"
+        s = (101 * s10) + s10[0:3]
+        with open(fpath, 'w') as fd:
+            for i in range(int(fsize / 1024)):
+                fd.write(f"{i:09d}-{s}\n")
+            remain = int(fsize % 1024)
+            if remain != 0:
+                i = int(fsize / 1024) + 1
+                s = f"{i:09d}-{s}\n"
+                fd.write(s[0:remain])
+        return fpath
+


### PR DESCRIPTION
Accurately report the bytes sent for a request in the '%O' Log format.

  This addresses #203, a long outstanding issue where mod_h2 has reported
   numbers over-eagerly from internal buffering and not what has actually
   been placed on the connection.
   The numbers are now the same with and without H2CopyFiles enabled.