### PR TITLE
New directive 'H2EarlyHint'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+ * New directive 'H2EarlyHint name value' to add headers to a response,
+   picked up already when a "103 Early Hints" response is sent. 'name' and
+   'value' must comply to the HTTP field restrictions.
+   This directive can be repeated several times and header fields of the
+   same names add. Sending a 'Link' header with 'preload' relation will
+   also cause a HTTP/2 PUSH if enabled and supported by the client.
+ * accurately report the bytes sent for a request in the '%O' Log format.
+   This addresses #203, a long outstanding issue where mod_h2 has reported
+   numbers over-eagerly from internal buffering and not what has actually
+   been placed on the connection.
+   The numbers are now the same with and without H2CopyFiles enabled.
+
 v2.0.14
 --------------------------------------------------------------------------------
  * fixed a crash during connection termination. See Apache PR 66539.

--- a/mod_http2/h2_c2_filter.c
+++ b/mod_http2/h2_c2_filter.c
@@ -511,10 +511,10 @@ static apr_status_t pass_response(h2_conn_ctx_t *conn_ctx, ap_filter_t *f,
 {
     apr_bucket *b;
     apr_status_t status;
-
     h2_headers *response = h2_headers_create(parser->http_status,
                                              make_table(parser),
-                                             NULL, 0, parser->pool);
+                                             parser->c->notes,
+                                             0, parser->pool);
     apr_brigade_cleanup(parser->tmp);
     b = h2_bucket_headers_create(parser->c->bucket_alloc, response);
     APR_BRIGADE_INSERT_TAIL(parser->tmp, b);

--- a/mod_http2/h2_config.h
+++ b/mod_http2/h2_config.h
@@ -87,6 +87,7 @@ int h2_config_rgeti(request_rec *r, h2_config_var_t var);
 apr_int64_t h2_config_rgeti64(request_rec *r, h2_config_var_t var);
 
 apr_array_header_t *h2_config_push_list(request_rec *r);
+apr_table_t *h2_config_early_headers(request_rec *r);
 
 
 void h2_get_workers_config(server_rec *s, int *pminw, int *pmaxw,

--- a/mod_http2/h2_headers.c
+++ b/mod_http2/h2_headers.c
@@ -144,6 +144,9 @@ h2_headers *h2_headers_rcreate(request_rec *r, int status,
                                const apr_table_t *header, apr_pool_t *pool)
 {
     h2_headers *headers = h2_headers_create(status, header, r->notes, 0, pool);
+    ap_log_rerror(APLOG_MARK, APLOG_TRACE1, headers->status, r,
+                  "h2_headers_rcreate(%ld): status=%d",
+                  (long)r->connection->id, status);
     if (headers->status == HTTP_FORBIDDEN) {
         request_rec *r_prev;
         for (r_prev = r; r_prev != NULL; r_prev = r_prev->prev) {

--- a/mod_http2/h2_stream.c
+++ b/mod_http2/h2_stream.c
@@ -1573,6 +1573,8 @@ static apr_status_t stream_do_response(h2_stream *stream)
          * denies it, submit resources to push */
         const char *s = apr_table_get(resp->notes, H2_PUSH_MODE_NOTE);
         if (!s || strcmp(s, "0")) {
+            ap_log_cerror(APLOG_MARK, APLOG_TRACE1, 0, c1,
+                          H2_STRM_MSG(stream, "submit pushes, note=%s"), s);
             h2_stream_submit_pushes(stream, resp);
         }
     }


### PR DESCRIPTION
New directive 'H2EarlyHint name value' to add headers to a response,
   picked up already when a "103 Early Hints" response is sent. 'name' and
   'value' must comply to the HTTP field restrictions.
   This directive can be repeated several times and header fields of the
   same names add. Sending a 'Link' header with 'preload' relation will
   also cause a HTTP/2 PUSH if enabled and supported by the client.