### PR TITLE
Report transaction timely

### DIFF
--- a/mod_http2/h2_mplx.c
+++ b/mod_http2/h2_mplx.c
@@ -589,6 +589,15 @@ static void c1_purge_streams(h2_mplx *m)
     apr_array_clear(m->spurge);
 }
 
+void h2_mplx_c1_going_keepalive(h2_mplx *m)
+{
+    H2_MPLX_ENTER_ALWAYS(m);
+    if (m->spurge->nelts) {
+        c1_purge_streams(m);
+    }
+    H2_MPLX_LEAVE(m);
+}
+
 apr_status_t h2_mplx_c1_poll(h2_mplx *m, apr_interval_time_t timeout,
                             stream_ev_callback *on_stream_input,
                             stream_ev_callback *on_stream_output,

--- a/mod_http2/h2_mplx.h
+++ b/mod_http2/h2_mplx.h
@@ -212,6 +212,14 @@ const struct h2_stream *h2_mplx_c2_stream_get(h2_mplx *m, int stream_id);
  */
 apr_status_t h2_mplx_worker_pop_c2(h2_mplx *m, conn_rec **out_c2);
 
+
+/**
+ * Session processing is entering KEEPALIVE, e.g. giving control
+ * to the MPM for monitoring incoming socket events only.
+ * Last chance for maintenance work before losing control.
+ */
+void h2_mplx_c1_going_keepalive(h2_mplx *m);
+
 #define H2_MPLX_MSG(m, msg)     \
     "h2_mplx(%d-%lu): "msg, m->child_num, (unsigned long)m->id
 

--- a/mod_http2/h2_session.c
+++ b/mod_http2/h2_session.c
@@ -1947,7 +1947,8 @@ leaving:
         ap_log_cerror( APLOG_MARK, APLOG_TRACE3, status, c,
                       H2_SSSN_MSG(session, "process returns")); 
     }
-    
+    h2_mplx_c1_going_keepalive(session->mplx);
+
     if (session->state == H2_SESSION_ST_DONE) {
         if (session->local.error) {
             char buffer[128];

--- a/test/modules/http2/test_004_post.py
+++ b/test/modules/http2/test_004_post.py
@@ -152,46 +152,6 @@ class TestPost:
     def test_h2_004_25(self, env, name, repeat):
         self.nghttp_upload_and_verify(env, name, ["--no-content-length"])
 
-    def test_h2_004_30(self, env):
-        # issue: #203
-        resource = "data-1k"
-        full_length = 1000
-        chunk = 200
-        self.curl_upload_and_verify(env, resource, ["-v", "--http2"])
-        logfile = os.path.join(env.server_logs_dir, "test_004_30")
-        if os.path.isfile(logfile):
-            os.remove(logfile)
-        H2Conf(env).add("""
-LogFormat "{ \\"request\\": \\"%r\\", \\"status\\": %>s, \\"bytes_resp_B\\": %B, \\"bytes_tx_O\\": %O, \\"bytes_rx_I\\": %I, \\"bytes_rx_tx_S\\": %S }" issue_203
-CustomLog logs/test_004_30 issue_203
-        """).add_vhost_cgi().install()
-        assert env.apache_restart() == 0
-        url = env.mkurl("https", "cgi", "/files/{0}".format(resource))
-        r = env.curl_get(url, 5, options=["--http2"])
-        assert r.response["status"] == 200
-        r = env.curl_get(url, 5, options=["--http1.1", "-H", "Range: bytes=0-{0}".format(chunk-1)])
-        assert 206 == r.response["status"]
-        assert chunk == len(r.response["body"].decode('utf-8'))
-        r = env.curl_get(url, 5, options=["--http2", "-H", "Range: bytes=0-{0}".format(chunk-1)])
-        assert 206 == r.response["status"]
-        assert chunk == len(r.response["body"].decode('utf-8'))
-        # Wait for log completeness
-        time.sleep(1)
-        # now check what response lengths have actually been reported
-        lines = open(logfile).readlines()
-        log_h2_full = json.loads(lines[-3])
-        log_h1 = json.loads(lines[-2])
-        log_h2 = json.loads(lines[-1])
-        assert log_h2_full['bytes_rx_I'] > 0
-        assert log_h2_full['bytes_resp_B'] == full_length
-        assert log_h2_full['bytes_tx_O'] > full_length
-        assert log_h1['bytes_rx_I'] > 0         # input bytes received
-        assert log_h1['bytes_resp_B'] == chunk  # response bytes sent (payload)
-        assert log_h1['bytes_tx_O'] > chunk     # output bytes sent
-        assert log_h2['bytes_rx_I'] > 0
-        assert log_h2['bytes_resp_B'] == chunk
-        assert log_h2['bytes_tx_O'] > chunk
-        
     def test_h2_004_40(self, env):
         # echo content using h2test_module "echo" handler
         def post_and_verify(fname, options=None):

--- a/test/modules/http2/test_008_ranges.py
+++ b/test/modules/http2/test_008_ranges.py
@@ -1,3 +1,5 @@
+import inspect
+import json
 import os
 import pytest
 
@@ -5,28 +7,74 @@ from .env import H2Conf, H2TestEnv
 
 
 @pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
-class TestGet:
+class TestRanges:
+
+    LOGFILE = ""
 
     @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env):
+        TestRanges.LOGFILE = os.path.join(env.server_logs_dir, "test_008")
+        TestRanges.SRCDIR = os.path.dirname(inspect.getfile(TestRanges))
+        if os.path.isfile(TestRanges.LOGFILE):
+            os.remove(TestRanges.LOGFILE)
         destdir = os.path.join(env.gen_dir, 'apache/htdocs/test1')
         env.make_data_file(indir=destdir, fname="data-100m", fsize=100*1024*1024)
-        conf = H2Conf(env=env, extras={
-            'base': [
-                'LogFormat "{\\"request\\": \\"%r\\", \\"status\\": \\"%>s\\", \\"recv\\": %I, \\"sent\\": %O, \\"ms\\": %D}" combined',
-            ]
-        })
-        conf.add_vhost_cgi(
-            proxy_self=True, h2proxy_self=True
-        ).add_vhost_test1(
-            proxy_self=True, h2proxy_self=True
-        )
+        conf = H2Conf(env=env)
+        conf.add([
+            "CustomLog logs/test_008 combined"
+        ])
+        conf.add_vhost_cgi()
+        conf.add_vhost_test1()
         conf.install()
         assert env.apache_restart() == 0
 
-    def test_h2_008_01(self, env, repeat):
+    def test_h2_008_01(self, env):
+        # issue: #203
+        resource = "data-1k"
+        full_length = 1000
+        chunk = 200
+        self.curl_upload_and_verify(env, resource, ["-v", "--http2"])
+        assert env.apache_restart() == 0
+        url = env.mkurl("https", "cgi", f"/files/{resource}?01full")
+        r = env.curl_get(url, 5, options=["--http2"])
+        assert r.response["status"] == 200
+        url = env.mkurl("https", "cgi", f"/files/{resource}?01range")
+        r = env.curl_get(url, 5, options=["--http1.1", "-H", "Range: bytes=0-{0}".format(chunk-1)])
+        assert 206 == r.response["status"]
+        assert chunk == len(r.response["body"].decode('utf-8'))
+        r = env.curl_get(url, 5, options=["--http2", "-H", "Range: bytes=0-{0}".format(chunk-1)])
+        assert 206 == r.response["status"]
+        assert chunk == len(r.response["body"].decode('utf-8'))
+        # Restart for logs to be flushed out
+        assert env.apache_restart() == 0
+        # now check what response lengths have actually been reported
+        detected = {}
+        for line in open(TestRanges.LOGFILE).readlines():
+            e = json.loads(line)
+            if e['request'] == f'GET /files/{resource}?01full HTTP/2.0':
+                assert e['bytes_rx_I'] > 0
+                assert e['bytes_resp_B'] == full_length
+                assert e['bytes_tx_O'] > full_length
+                detected['h2full'] = 1
+            elif e['request'] == f'GET /files/{resource}?01range HTTP/2.0':
+                assert e['bytes_rx_I'] > 0
+                assert e['bytes_resp_B'] == chunk
+                assert e['bytes_tx_O'] > chunk
+                assert e['bytes_tx_O'] < chunk + 256 # response + frame stuff
+                detected['h2range'] = 1
+            elif e['request'] == f'GET /files/{resource}?01range HTTP/1.1':
+                assert e['bytes_rx_I'] > 0         # input bytes received
+                assert e['bytes_resp_B'] == chunk  # response bytes sent (payload)
+                assert e['bytes_tx_O'] > chunk     # output bytes sent
+                detected['h1range'] = 1
+        assert 'h1range' in detected, f'HTTP/1.1 range request not found in {TestRanges.LOGFILE}'
+        assert 'h2range' in detected, f'HTTP/2 range request not found in {TestRanges.LOGFILE}'
+        assert 'h2full' in detected, f'HTTP/2 full request not found in {TestRanges.LOGFILE}'
+
+    def test_h2_008_02(self, env, repeat):
         path = '/002.jpg'
-        url = env.mkurl("https", "test1", path)
+        res_len = 90364
+        url = env.mkurl("https", "test1", f'{path}?02full')
         r = env.curl_get(url, 5)
         assert r.response["status"] == 200
         assert "HTTP/2" == r.response["protocol"]
@@ -35,22 +83,62 @@ class TestGet:
         assert "bytes" == h["accept-ranges"]
         assert "content-length" in h
         clen = h["content-length"]
-        assert int(clen) == 90364
+        assert int(clen) == res_len
         # get the first 1024 bytes of the resource, 206 status, but content-length as original
-        for i in range(10):
-            r = env.curl_get(url, 5, options=["-H", "range: bytes=0-1023"])
-            if r.response["status"] != 503:
-                break
+        url = env.mkurl("https", "test1", f'{path}?02range')
+        r = env.curl_get(url, 5, options=["-H", "range: bytes=0-1023"])
         assert 206 == r.response["status"]
         assert "HTTP/2" == r.response["protocol"]
         assert 1024 == len(r.response["body"])
         assert "content-length" in h
         assert clen == h["content-length"]
+        # Restart for logs to be flushed out
+        assert env.apache_restart() == 0
+        # now check what response lengths have actually been reported
+        found = False
+        for line in open(TestRanges.LOGFILE).readlines():
+            e = json.loads(line)
+            if e['request'] == f'GET {path}?02range HTTP/2.0':
+                assert e['bytes_rx_I'] > 0
+                assert e['bytes_resp_B'] == 1024
+                assert e['bytes_tx_O'] > 1024
+                assert e['bytes_tx_O'] < 1024 + 256  # response  and frame stuff
+                found = True
+                break
+        assert found, f'request not found in {self.LOGFILE}'
 
-    def test_h2_008_02(self, env, repeat):
+    # send a paced curl download that aborts in the middle of the transfer
+    def test_h2_008_03(self, env, repeat):
         path = '/data-100m'
-        url = env.mkurl("https", "test1", path)
+        url = env.mkurl("https", "test1", f'{path}?03broken')
         r = env.curl_get(url, 5, options=[
             '--limit-rate', '2k', '-m', '2'
         ])
         assert r.exit_code != 0, f'{r}'
+        found = False
+        for line in open(TestRanges.LOGFILE).readlines():
+            e = json.loads(line)
+            if e['request'] == f'GET {path}?03broken HTTP/2.0':
+                assert e['bytes_rx_I'] > 0
+                assert e['bytes_resp_B'] == 100*1024*1024
+                assert e['bytes_tx_O'] > 1024
+                assert e['bytes_tx_O'] < 5*1024*1024  # curl buffers, but not that much
+                found = True
+                break
+        assert found, f'request not found in {self.LOGFILE}'
+
+    # upload and GET again using curl, compare to original content
+    def curl_upload_and_verify(self, env, fname, options=None):
+        url = env.mkurl("https", "cgi", "/upload.py")
+        fpath = os.path.join(env.gen_dir, fname)
+        r = env.curl_upload(url, fpath, options=options)
+        assert r.exit_code == 0, f"{r}"
+        assert 200 <= r.response["status"] < 300
+
+        r2 = env.curl_get(r.response["header"]["location"])
+        assert r2.exit_code == 0
+        assert r2.response["status"] == 200
+        with open(os.path.join(TestRanges.SRCDIR, fpath), mode='rb') as file:
+            src = file.read()
+        assert src == r2.response["body"]
+

--- a/test/modules/http2/test_009_timing.py
+++ b/test/modules/http2/test_009_timing.py
@@ -1,0 +1,74 @@
+import inspect
+import json
+import os
+import pytest
+
+from .env import H2Conf, H2TestEnv
+
+
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+class TestTiming:
+
+    LOGFILE = ""
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env):
+        TestTiming.LOGFILE = os.path.join(env.server_logs_dir, "test_009")
+        if os.path.isfile(TestTiming.LOGFILE):
+            os.remove(TestTiming.LOGFILE)
+        conf = H2Conf(env=env)
+        conf.add([
+            "CustomLog logs/test_009 combined"
+        ])
+        conf.add_vhost_cgi()
+        conf.add_vhost_test1()
+        conf.install()
+        assert env.apache_restart() == 0
+
+    # check that we get a positive time_taken reported on a simple GET
+    def test_h2_009_01(self, env):
+        path = '/002.jpg'
+        url = env.mkurl("https", "test1", f'{path}?01')
+        args = [
+            env.h2load, "-n", "1", "-c", "1", "-m", "1",
+            f"--connect-to=localhost:{env.https_port}",
+            f"--base-uri={url}", url
+        ]
+        r = env.run(args)
+        # Restart for logs to be flushed out
+        assert env.apache_restart() == 0
+        found = False
+        for line in open(TestTiming.LOGFILE).readlines():
+            e = json.loads(line)
+            if e['request'] == f'GET {path}?01 HTTP/2.0':
+                assert e['time_taken'] > 0
+                found = True
+        assert found, f'request not found in {TestTiming.LOGFILE}'
+
+    # test issue #253, where time_taken in a keepalive situation is not
+    # reported until the next request arrives
+    def test_h2_009_02(self, env):
+        baseurl = env.mkurl("https", "test1", '/')
+        tscript = os.path.join(env.gen_dir, 'h2load-timing-009_02')
+        with open(tscript, 'w') as fd:
+            fd.write('\n'.join([
+                f'0.0\t/002.jpg?02a',        # 1st request right away
+                f'1000.0\t/002.jpg?02b',     # 2nd a second later
+            ]))
+        args = [
+            env.h2load,
+            f'--timing-script-file={tscript}',
+            f"--connect-to=localhost:{env.https_port}",
+            f"--base-uri={baseurl}"
+        ]
+        r = env.run(args)
+        # Restart for logs to be flushed out
+        assert env.apache_restart() == 0
+        found = False
+        for line in open(TestTiming.LOGFILE).readlines():
+            e = json.loads(line)
+            if e['request'] == f'GET /002.jpg?02a HTTP/2.0':
+                assert e['time_taken'] > 0
+                assert e['time_taken'] < 500 * 1000, f'time for 1st request not reported correctly'
+                found = True
+        assert found, f'request not found in {TestTiming.LOGFILE}'

--- a/test/pyhttpd/conf/httpd.conf.template
+++ b/test/pyhttpd/conf/httpd.conf.template
@@ -9,7 +9,7 @@ Include "conf/modules.conf"
 DocumentRoot "${server_dir}/htdocs"
 
 <IfModule log_config_module>
-    LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" %k" combined
+    LogFormat "{ \"request\": \"%r\", \"status\": %>s, \"bytes_resp_B\": %B, \"bytes_tx_O\": %O, \"bytes_rx_I\": %I, \"bytes_rx_tx_S\": %S, \"time_taken\": %D }" combined
     LogFormat "%h %l %u %t \"%r\" %>s %b" common
     CustomLog "logs/access_log" combined
 


### PR DESCRIPTION
    Perform maintenance tasks before returning to MPM keepalive handling

    - fixes #253 where stream cleanup did not happen before the MPM called
      back on more client IO. This led to late reporting of finished requests
      and wrong times for request duration
