### PR TITLE
 * mod_proxy_http2: fix retry handling to not leak temporary errors.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+ * mod_proxy_http2: fix retry handling to not leak temporary errors.
+   On detecting that that an existing connection was shutdown by the other
+   side, a 503 response leaked even though the request was retried on a
+   fresh connection.
  * Fixed a bug that applied request filters twice on redirects. This led to
    double chunked-encoding internally on POST requests without content-length.
    Fix by Yann Ylavic.

--- a/mod_http2/h2_proxy_session.c
+++ b/mod_http2/h2_proxy_session.c
@@ -1375,12 +1375,9 @@ static void ev_stream_done(h2_proxy_session *session, int stream_id,
                           session->id, stream_id, touched, stream->error_code);
 
             if (status != APR_SUCCESS) {
-                b = ap_bucket_error_create(HTTP_SERVICE_UNAVAILABLE, NULL, stream->r->pool,
-                                           stream->r->connection->bucket_alloc);
-                APR_BRIGADE_INSERT_TAIL(stream->output, b);
-                b = apr_bucket_eos_create(stream->r->connection->bucket_alloc);
-                APR_BRIGADE_INSERT_TAIL(stream->output, b);
-                ap_pass_brigade(stream->r->output_filters, stream->output);
+              /* stream failed, error reporting is done by caller
+               * of proxy_session, e.g. mod_proxy_http2 which also
+               * decides about retries. */
             }
             else if (!stream->data_received) {
                 /* if the response had no body, this is the time to flush

--- a/test/modules/http2/env.py
+++ b/test/modules/http2/env.py
@@ -70,7 +70,7 @@ class H2TestEnv(HttpdTestEnv):
             "H2MaxWorkers 64",
             "Protocols h2 http/1.1 h2c",
         ])
-        self.add_httpd_log_modules(["http2", "proxy_http2", "h2test", "proxy", "proxy_http", "rewrite"])
+        self.add_httpd_log_modules(["http2", "proxy_http2", "h2test", "proxy", "proxy_http"])
         self.add_cert_specs([
             CertificateSpec(domains=[
                 f"push.{self._http_tld}",

--- a/test/modules/http2/test_003_get.py
+++ b/test/modules/http2/test_003_get.py
@@ -197,11 +197,7 @@ content-type: text/html
     def test_h2_003_50(self, env, path, repeat):
         # check that the resource supports ranges and we see its raw content-length
         url = env.mkurl("https", "test1", path)
-        # TODO: sometimes we see a 503 here from h2proxy
-        for i in range(10):
-            r = env.curl_get(url, 5)
-            if r.response["status"] != 503:
-                break
+        r = env.curl_get(url, 5)
         assert r.response["status"] == 200
         assert "HTTP/2" == r.response["protocol"]
         h = r.response["header"]
@@ -210,10 +206,7 @@ content-type: text/html
         assert "content-length" in h
         clen = h["content-length"]
         # get the first 1024 bytes of the resource, 206 status, but content-length as original
-        for i in range(10):
-            r = env.curl_get(url, 5, options=["-H", "range: bytes=0-1023"])
-            if r.response["status"] != 503:
-                break
+        r = env.curl_get(url, 5, options=["-H", "range: bytes=0-1023"])
         assert 206 == r.response["status"]
         assert "HTTP/2" == r.response["protocol"]
         assert 1024 == len(r.response["body"])

--- a/test/modules/http2/test_004_post.py
+++ b/test/modules/http2/test_004_post.py
@@ -18,15 +18,7 @@ class TestPost:
     @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env):
         TestPost._local_dir = os.path.dirname(inspect.getfile(TestPost))
-        conf = H2Conf(env, extras={
-            f'cgi.{env.http_tld}': [
-                '# SetEnv proxy-sendcl 1',
-                f'<Directory {env.server_docs_dir}/cgi/xxx>',
-                '  RewriteEngine On',
-                '  RewriteRule .* /proxy/echo.py [QSA]',
-                '</Directory>',
-            ]
-        })
+        conf = H2Conf(env)
         conf.add_vhost_cgi(proxy_self=True).install()
         assert env.apache_restart() == 0
 
@@ -191,6 +183,16 @@ class TestPost:
 
     def test_h2_004_41(self, env):
         # reproduce PR66597, double chunked encoding on redirects
+        conf = H2Conf(env, extras={
+            f'cgi.{env.http_tld}': [
+                f'<Directory {env.server_docs_dir}/cgi/xxx>',
+                '  RewriteEngine On',
+                '  RewriteRule .* /proxy/echo.py [QSA]',
+                '</Directory>',
+            ]
+        })
+        conf.add_vhost_cgi(proxy_self=True).install()
+        assert env.apache_restart() == 0
         url = env.mkurl("https", "cgi", "/xxx/test.json")
         r = env.curl_post_data(url, data="0123456789", options=[])
         assert r.exit_code == 0

--- a/test/modules/http2/test_104_padding.py
+++ b/test/modules/http2/test_104_padding.py
@@ -13,57 +13,63 @@ class TestPadding:
 
     @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env):
+        def add_echo_handler(conf):
+            conf.add([
+                "<Location \"/h2test/echo\">",
+                "    SetHandler h2test-echo",
+                "</Location>",
+            ])
+
         conf = H2Conf(env)
         conf.start_vhost(domains=[f"ssl.{env.http_tld}"], port=env.https_port, doc_root="htdocs/cgi")
-        conf.add("AddHandler cgi-script .py")
+        add_echo_handler(conf)
         conf.end_vhost()
         conf.start_vhost(domains=[f"pad0.{env.http_tld}"], port=env.https_port, doc_root="htdocs/cgi")
         conf.add("H2Padding 0")
-        conf.add("AddHandler cgi-script .py")
+        add_echo_handler(conf)
         conf.end_vhost()
         conf.start_vhost(domains=[f"pad1.{env.http_tld}"], port=env.https_port, doc_root="htdocs/cgi")
         conf.add("H2Padding 1")
-        conf.add("AddHandler cgi-script .py")
+        add_echo_handler(conf)
         conf.end_vhost()
         conf.start_vhost(domains=[f"pad2.{env.http_tld}"], port=env.https_port, doc_root="htdocs/cgi")
         conf.add("H2Padding 2")
-        conf.add("AddHandler cgi-script .py")
+        add_echo_handler(conf)
         conf.end_vhost()
         conf.start_vhost(domains=[f"pad3.{env.http_tld}"], port=env.https_port, doc_root="htdocs/cgi")
         conf.add("H2Padding 3")
-        conf.add("AddHandler cgi-script .py")
+        add_echo_handler(conf)
         conf.end_vhost()
         conf.start_vhost(domains=[f"pad8.{env.http_tld}"], port=env.https_port, doc_root="htdocs/cgi")
         conf.add("H2Padding 8")
-        conf.add("AddHandler cgi-script .py")
+        add_echo_handler(conf)
         conf.end_vhost()
         conf.install()
         assert env.apache_restart() == 0
 
     # default paddings settings: 0 bits
-    def test_h2_104_01(self, env):
-        url = env.mkurl("https", "ssl", "/echo.py")
+    def test_h2_104_01(self, env, repeat):
+        url = env.mkurl("https", "ssl", "/h2test/echo")
         # we get 2 frames back: one with data and an empty one with EOF
         # check the number of padding bytes is as expected
         for data in ["x", "xx", "xxx", "xxxx", "xxxxx", "xxxxxx", "xxxxxxx", "xxxxxxxx"]:
             r = env.nghttp().post_data(url, data, 5)
             assert r.response["status"] == 200
-            assert r.results["paddings"] == [
-                frame_padding(len(data)+1, 0), 
-                frame_padding(0, 0)
-            ]
+            for i in r.results["paddings"]:
+                assert i == frame_padding(len(data)+1, 0)
 
     # 0 bits of padding
     def test_h2_104_02(self, env):
-        url = env.mkurl("https", "pad0", "/echo.py")
+        url = env.mkurl("https", "pad0", "/h2test/echo")
         for data in ["x", "xx", "xxx", "xxxx", "xxxxx", "xxxxxx", "xxxxxxx", "xxxxxxxx"]:
             r = env.nghttp().post_data(url, data, 5)
             assert r.response["status"] == 200
-            assert r.results["paddings"] == [0, 0]
+            for i in r.results["paddings"]:
+                assert i == 0
 
     # 1 bit of padding
     def test_h2_104_03(self, env):
-        url = env.mkurl("https", "pad1", "/echo.py")
+        url = env.mkurl("https", "pad1", "/h2test/echo")
         for data in ["x", "xx", "xxx", "xxxx", "xxxxx", "xxxxxx", "xxxxxxx", "xxxxxxxx"]:
             r = env.nghttp().post_data(url, data, 5)
             assert r.response["status"] == 200
@@ -72,7 +78,7 @@ class TestPadding:
 
     # 2 bits of padding
     def test_h2_104_04(self, env):
-        url = env.mkurl("https", "pad2", "/echo.py")
+        url = env.mkurl("https", "pad2", "/h2test/echo")
         for data in ["x", "xx", "xxx", "xxxx", "xxxxx", "xxxxxx", "xxxxxxx", "xxxxxxxx"]:
             r = env.nghttp().post_data(url, data, 5)
             assert r.response["status"] == 200
@@ -81,7 +87,7 @@ class TestPadding:
 
     # 3 bits of padding
     def test_h2_104_05(self, env):
-        url = env.mkurl("https", "pad3", "/echo.py")
+        url = env.mkurl("https", "pad3", "/h2test/echo")
         for data in ["x", "xx", "xxx", "xxxx", "xxxxx", "xxxxxx", "xxxxxxx", "xxxxxxxx"]:
             r = env.nghttp().post_data(url, data, 5)
             assert r.response["status"] == 200
@@ -90,7 +96,7 @@ class TestPadding:
 
     # 8 bits of padding
     def test_h2_104_06(self, env):
-        url = env.mkurl("https", "pad8", "/echo.py")
+        url = env.mkurl("https", "pad8", "/h2test/echo")
         for data in ["x", "xx", "xxx", "xxxx", "xxxxx", "xxxxxx", "xxxxxxx", "xxxxxxxx"]:
             r = env.nghttp().post_data(url, data, 5)
             assert r.response["status"] == 200

--- a/test/modules/http2/test_500_proxy.py
+++ b/test/modules/http2/test_500_proxy.py
@@ -49,11 +49,11 @@ class TestProxy:
             src = file.read()
         assert r2.response["body"] == src
 
-    def test_h2_500_10(self, env, repeat):
-        self.curl_upload_and_verify(env, "data-1k", ["--http2"])
-        self.curl_upload_and_verify(env, "data-10k", ["--http2"])
-        self.curl_upload_and_verify(env, "data-100k", ["--http2"])
-        self.curl_upload_and_verify(env, "data-1m", ["--http2"])
+    @pytest.mark.parametrize("name", [
+        "data-1k", "data-10k", "data-100k", "data-1m",
+    ])
+    def test_h2_500_10(self, env, name, repeat):
+        self.curl_upload_and_verify(env, name, ["--http2"])
 
     def test_h2_500_11(self, env):
         self.curl_upload_and_verify(env, "data-1k", [
@@ -77,17 +77,17 @@ class TestProxy:
                 fd.write(r.stderr)
             assert r.response["body"] == src
 
-    def test_h2_500_20(self, env, repeat):
-        self.nghttp_post_and_verify(env, "data-1k", [])
-        self.nghttp_post_and_verify(env, "data-10k", [])
-        self.nghttp_post_and_verify(env, "data-100k", [])
-        self.nghttp_post_and_verify(env, "data-1m", [])
+    @pytest.mark.parametrize("name", [
+        "data-1k", "data-10k", "data-100k", "data-1m",
+    ])
+    def test_h2_500_20(self, env, name, repeat):
+        self.nghttp_post_and_verify(env, name, [])
 
-    def test_h2_500_21(self, env, repeat):
-        self.nghttp_post_and_verify(env, "data-1k", ["--no-content-length"])
-        self.nghttp_post_and_verify(env, "data-10k", ["--no-content-length"])
-        self.nghttp_post_and_verify(env, "data-100k", ["--no-content-length"])
-        self.nghttp_post_and_verify(env, "data-1m", ["--no-content-length"])
+    @pytest.mark.parametrize("name", [
+        "data-1k", "data-10k", "data-100k", "data-1m",
+    ])
+    def test_h2_500_21(self, env, name, repeat):
+        self.nghttp_post_and_verify(env, name, ["--no-content-length"])
 
     # upload and GET again using nghttp, compare to original content
     def nghttp_upload_and_verify(self, env, fname, options=None):
@@ -107,17 +107,17 @@ class TestProxy:
             src = file.read()
         assert src == r2.response["body"]
 
-    def test_h2_500_22(self, env):
-        self.nghttp_upload_and_verify(env, "data-1k", [])
-        self.nghttp_upload_and_verify(env, "data-10k", [])
-        self.nghttp_upload_and_verify(env, "data-100k", [])
-        self.nghttp_upload_and_verify(env, "data-1m", [])
+    @pytest.mark.parametrize("name", [
+        "data-1k", "data-10k", "data-100k", "data-1m",
+    ])
+    def test_h2_500_22(self, env, name):
+        self.nghttp_upload_and_verify(env, name, [])
 
-    def test_h2_500_23(self, env):
-        self.nghttp_upload_and_verify(env, "data-1k", ["--no-content-length"])
-        self.nghttp_upload_and_verify(env, "data-10k", ["--no-content-length"])
-        self.nghttp_upload_and_verify(env, "data-100k", ["--no-content-length"])
-        self.nghttp_upload_and_verify(env, "data-1m", ["--no-content-length"])
+    @pytest.mark.parametrize("name", [
+        "data-1k", "data-10k", "data-100k", "data-1m",
+    ])
+    def test_h2_500_23(self, env, name):
+        self.nghttp_upload_and_verify(env, name, ["--no-content-length"])
 
     # upload using nghttp and check returned status
     def nghttp_upload_stat(self, env, fname, options=None):
@@ -130,7 +130,7 @@ class TestProxy:
         assert r.response["header"]["location"]
 
     def test_h2_500_24(self, env):
-        for i in range(100):
+        for i in range(50):
             self.nghttp_upload_stat(env, "data-1k", ["--no-content-length"])
 
     # lets do some error tests


### PR DESCRIPTION
   On detecting that that an existing connection was shutdown by the other
   side, a 503 response leaked even though the request was retried on a
   fresh connection.