### PR TITLE
fix compilation error when using PROXY_CANONENC_NOENCODEDSLASHENCODING

### DIFF
--- a/mod_http2/mod_proxy_http2.c
+++ b/mod_http2/mod_proxy_http2.c
@@ -158,8 +158,8 @@ static int proxy_http2_canon(request_rec *r, char *url)
             search = r->args;
         }
         else {
+#ifdef PROXY_CANONENC_NOENCODEDSLASHENCODING
             core_dir_config *d = ap_get_core_module_config(r->per_dir_config);
- #ifdef PROXY_CANONENC_NOENCODEDSLASHENCODING
             int flags = d->allow_encoded_slashes && !d->decode_encoded_slashes ? PROXY_CANONENC_NOENCODEDSLASHENCODING : 0;
 
             path = ap_proxy_canonenc_ex(r->pool, url, (int)strlen(url),


### PR DESCRIPTION
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -std=c99 -D_GNU_SOURCE -Werror -I/usr/include/httpd -I/usr/include/apr-1 -DLINUX -D_REENTRANT -D_GNU_SOURCE -DH2_NG2_STREAM_API -DH2_NG2_CHANGE_PRIO -DH2_NG2_INVALID_HEADER_CB -DH2_NG2_LOCAL_WIN_SIZE -DH2_NG2_NO_CLOSED_STREAMS -DH2_NG2_RFC9113_STRICTNESS -DH2_OPENSSL -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/generic-hardened-cc1 -fasynchronous-unwind-tables -fstack-clash-protection -c mod_proxy_http2.c  -fPIC -DPIC -o .libs/mod_proxy_http2_la-mod_proxy_http2.o
 mod_proxy_http2.c: In function 'proxy_http2_canon':
 mod_proxy_http2.c:161:30: error: unused variable 'd' [-Werror=unused-variable]
   161 |             core_dir_config *d = ap_get_core_module_config(r->per_dir_config);
       |                              ^
 cc1: all warnings being treated as errors
 make[1]: *** [Makefile:820: mod_proxy_http2_la-mod_proxy_http2.lo] Error 1
 make[1]: Leaving directory '/home/abuild/rpmbuild/BUILD/mod_http2-2.0.20/mod_http2'
 make[1]: *** Waiting for unfinished jobs....
 
 gcc version: gcc-12.3.1