### PR TITLE
Distribute .py files needed by the test suite

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,9 @@ EXTRA_DIST     = \
     test/Makefile.am \
 	test/clients \
 	test/modules \
-	test/pyhttpd
+	test/pyhttpd \
+	test/conftest.py \
+	test/load_test.py
 
 
 dist_doc_DATA   = README README.md LICENSE


### PR DESCRIPTION
Hello Stefan,

during test suite setup I came across some issues.

1) without having conftest.py, I was getting many errors like:

```file /tmp/tmp.6rABq4Ca9P/BUILD/mod_http2-2.0.26/test/modules/http2/test_711_load_post_cgi.py, line 60
      def test_h2_711_12(self, env, repeat):
E       fixture 'repeat' not found
>       available fixtures: __pytest_repeat_step_number, _class_scope, _session_scope, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, env, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/tmp/tmp.6rABq4Ca9P/BUILD/mod_http2-2.0.26/test/modules/http2/test_711_load_post_cgi.py:60
```

2) It would be good to mention in README.md, that also following python3 modules are needed by mod_http2's TS:

```
pip3 install cryptography pytest-repeat websockets python-multipart
```

3) I saw that load_test.py is also reachable by Makefile, so it might be a good idea to include it as well?

