### PR TITLE
async processing on client flow block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ test/gen/
 test/pyhttpd/config.ini
 test/.pytest_cache
 .idea
+issues

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+ * When flow control to the client blocks, needing a WINDOW_UPDATE to make
+   further progress, HTTP/2 connection processing returns to the MPM.
+   If using "mpm_event", this will free a worker.
+
 v2.0.27
 --------------------------------------------------------------------------------
  * Added `cmake` support provided by @jfclere. Many thanks.

--- a/mod_http2/h2_c1.c
+++ b/mod_http2/h2_c1.c
@@ -116,7 +116,7 @@ cleanup:
 apr_status_t h2_c1_run(conn_rec *c)
 {
     apr_status_t status;
-    int mpm_state = 0;
+    int mpm_state = 0, keepalive = 0;
     h2_conn_ctx_t *conn_ctx = h2_conn_ctx_get(c);
     
     ap_assert(conn_ctx);
@@ -127,7 +127,7 @@ apr_status_t h2_c1_run(conn_rec *c)
             c->cs->state = CONN_STATE_HANDLER;
         }
     
-        status = h2_session_process(conn_ctx->session, async_mpm);
+        status = h2_session_process(conn_ctx->session, async_mpm, &keepalive);
         
         if (APR_STATUS_IS_EOF(status)) {
             ap_log_cerror(APLOG_MARK, APLOG_DEBUG, status, c, 
@@ -153,7 +153,7 @@ apr_status_t h2_c1_run(conn_rec *c)
             case H2_SESSION_ST_BUSY:
             case H2_SESSION_ST_WAIT:
                 c->cs->state = CONN_STATE_WRITE_COMPLETION;
-                if (c->cs && !conn_ctx->session->remote.emitted_count) {
+                if (!keepalive) {
                     /* let the MPM know that we are not done and want
                      * the Timeout behaviour instead of a KeepAliveTimeout
                      * See PR 63534. 

--- a/mod_http2/h2_mplx.h
+++ b/mod_http2/h2_mplx.h
@@ -197,6 +197,11 @@ apr_status_t h2_mplx_c1_streams_do(h2_mplx *m, h2_mplx_stream_cb *cb, void *ctx)
 int h2_mplx_c1_all_streams_want_send_data(h2_mplx *m);
 
 /**
+ * Return != 0 iff all open streams have send window exhausted
+ */
+int h2_mplx_c1_all_streams_send_win_exhausted(h2_mplx *m);
+
+/**
  * A stream has been RST_STREAM by the client. Abort
  * any processing going on and remove from processing
  * queue.

--- a/mod_http2/h2_session.h
+++ b/mod_http2/h2_session.h
@@ -144,8 +144,11 @@ void h2_session_event(h2_session *session, h2_session_event_t ev,
  * error occurred.
  *
  * @param session the sessionm to process
+ * @param async if mpm is async
+ * @param pkeepalive on return, != 0 if connection to be put into keepalive
+ *                   behaviour and timouts
  */
-apr_status_t h2_session_process(h2_session *session, int async);
+apr_status_t h2_session_process(h2_session *session, int async, int *pkeepalive);
 
 /**
  * Last chance to do anything before the connection is closed.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '.'))
 
 from pyhttpd.env import HttpdTestEnv
 
-def pytest_report_header(config, startdir):
+def pytest_report_header(config):
     env = HttpdTestEnv()
     return f"[apache httpd: {env.get_httpd_version()}, mpm: {env.mpm_module}, {env.prefix}]"
 

--- a/test/modules/http2/test_700_load_get.py
+++ b/test/modules/http2/test_700_load_get.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from .env import H2Conf, H2TestEnv
@@ -10,20 +11,25 @@ class TestLoadGet:
 
     @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env):
-        H2Conf(env).add_vhost_cgi().add_vhost_test1().install()
+        destdir = os.path.join(env.gen_dir, 'apache/htdocs/test1')
+        env.make_data_file(indir=destdir, fname="data-100k", fsize=100*1024)
+        conf = H2Conf(env).add_vhost_cgi().add_vhost_test1()
+        conf.add('LogLevel mpm_event:debug')
+        conf.add(f"StartServers 1")
+        conf.install()
         assert env.apache_restart() == 0
 
     def check_h2load_ok(self, env, r, n):
         assert 0 == r.exit_code
         r = env.h2load_status(r)
-        assert n == r.results["h2load"]["requests"]["total"], f'{r.results}'
-        assert n == r.results["h2load"]["requests"]["started"], f'{r.results}'
-        assert n == r.results["h2load"]["requests"]["done"], f'{r.results}'
-        assert n == r.results["h2load"]["requests"]["succeeded"], f'{r.results}'
-        assert n == r.results["h2load"]["status"]["2xx"], f'{r.results}'
-        assert 0 == r.results["h2load"]["status"]["3xx"], f'{r.results}'
-        assert 0 == r.results["h2load"]["status"]["4xx"], f'{r.results}'
-        assert 0 == r.results["h2load"]["status"]["5xx"], f'{r.results}'
+        assert n == r.results["h2load"]["requests"]["total"], f'\n{r.stdout}'
+        assert n == r.results["h2load"]["requests"]["started"], f'\n{r.stdout}'
+        assert n == r.results["h2load"]["requests"]["done"], f'\n{r.stdout}'
+        assert n == r.results["h2load"]["requests"]["succeeded"], f'\n{r.stdout}'
+        assert n == r.results["h2load"]["status"]["2xx"], f'\n{r.stdout}'
+        assert 0 == r.results["h2load"]["status"]["3xx"], f'\n{r.stdout}'
+        assert 0 == r.results["h2load"]["status"]["4xx"], f'\n{r.stdout}'
+        assert 0 == r.results["h2load"]["status"]["5xx"], f'\n{r.stdout}'
     
     # test load on cgi script, single connection, different sizes
     @pytest.mark.parametrize("start", [
@@ -61,3 +67,27 @@ class TestLoadGet:
                 args.append(env.mkurl("https", "cgi", ("/mnot164.py?count=%d&text=%s" % (start+(n*chunk)+i, text))))
             r = env.run(args)
             self.check_h2load_ok(env, r, chunk)
+
+    # test window sizes, connection and stream
+    @pytest.mark.parametrize("connbits,streambits", [
+        [10, 16],  # 1k connection window, 64k stream windows
+        [10, 30],  # 1k connection window, huge stream windows
+        [30, 8],  # huge conn window, 256 bytes stream windows
+    ])
+    def test_h2_700_20(self, env, connbits, streambits):
+        assert env.is_live()
+        n = 200
+        conns = 1
+        parallel = 10
+        args = [
+            env.h2load,
+            '-n', f'{n}', '-t', '1',
+            '-c', f'{conns}', '-m', f'{parallel}',
+            '-W', f'{connbits}',  # connection window bits
+            '-w', f'{streambits}',  # stream window bits
+            f'--connect-to=localhost:{env.https_port}',
+            f'--base-uri={env.mkurl("https", "test1", "/")}',
+            "/data-100k"
+        ]
+        r = env.run(args)
+        self.check_h2load_ok(env, r, n)


### PR DESCRIPTION
 * When flow control to the client blocks, needing a WINDOW_UPDATE to make
   further progress, HTTP/2 connection processing returns to the MPM.
   If using "mpm_event", this will free a worker.
