### PR TITLE
async block handling

### DIFF
--- a/mod_http2/h2_c2.c
+++ b/mod_http2/h2_c2.c
@@ -370,6 +370,11 @@ static apr_status_t h2_c2_filter_out(ap_filter_t* f, apr_bucket_brigade* bb)
     h2_conn_ctx_t *conn_ctx = h2_conn_ctx_get(f->c);
     apr_status_t rv;
 
+    if (bb == NULL) {
+        f->c->data_in_output_filters = 0;
+        return APR_SUCCESS;
+    }
+
     ap_assert(conn_ctx);
 #if AP_HAS_RESPONSE_BUCKETS
     if (!conn_ctx->has_final_response) {

--- a/test/pyhttpd/curl.py
+++ b/test/pyhttpd/curl.py
@@ -112,11 +112,11 @@ class CurlPiper:
         recv_times = []
         for line in "".join(recv_err).split('\n'):
             m = re.match(r'^\s*(\d+:\d+:\d+(\.\d+)?) <= Recv data, (\d+) bytes.*', line)
-            if m:
+            if m and int(m.group(3)) > 0:
                 recv_times.append(datetime.time.fromisoformat(m.group(1)))
         # received as many chunks as we sent
-        assert len(chunks) == len(recv_times), "received response not in {0} chunks, but {1}".format(
-            len(chunks), len(recv_times))
+        assert len(chunks) == len(recv_times), f"received response not in {len(chunks)} "\
+            f"chunks, but {len(recv_times)}: {recv_err}"
 
         def microsecs(tdelta):
             return ((tdelta.hour * 60 + tdelta.minute) * 60 + tdelta.second) * 1000000 + tdelta.microsecond


### PR DESCRIPTION
- only enable on newer HTTPD versions. 2.4.x versions still treat connections in the event MPM as KeepAlive and purge them on load.
- spelling fixes
- support for yield calls in c2 "network" filter