### PR TITLE
h2_mplx: Handle stream 0 in mplx_pollset_poll only once

### DIFF
--- a/mod_http2/h2_mplx.c
+++ b/mod_http2/h2_mplx.c
@@ -1262,7 +1262,7 @@ static apr_status_t mplx_pollset_poll(h2_mplx *m, apr_interval_time_t timeout,
                 if (on_stream_input) {
                     APR_ARRAY_PUSH(m->streams_ev_in, h2_stream*) = m->stream0;
                 }
-                continue;
+                break;
             }
         }
 


### PR DESCRIPTION
The `continue` has no effect because it's the last statement in the for loop. I think it should be a `break` so that `m->stream0` is added to `m->streams_ev_in` only once.