### PR TITLE
Replace apachectl with httpd/apache2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,21 +115,39 @@ CPPFLAGS="-I$($APXS -q includedir) -I$($APXS -q APR_INCLUDEDIR) $($APXS -q EXTRA
 HTTPD_VERSION="$($APXS -q HTTPD_VERSION)"
 AC_SUBST(HTTPD_VERSION)
 
-APACHECTL="$sbindir/apachectl"
-if test ! -x "$APACHECTL"; then
-    # rogue distros rename things! =)
-    APACHECTL="$sbindir/apache2ctl"
+HTTPD="$sbindir/httpd"
+if test -x "$HTTPD"; then
+  :  # all fine
+else
+  HTTPD="$sbindir/apache2"
+  if test -x "$HTTPD"; then
+    :  # all fine
+  else
+    HTTPD=""
+    AC_PATH_PROG([HTTPD], [httpd])
+    if test -x "$HTTPD"; then
+      :  # ok
+    else
+      HTTPD=""
+      AC_PATH_PROG([HTTPD], [apache2])
+      if test -x "$HTTPD"; then
+        :  # ok
+      else
+        AC_MSG_ERROR([httpd/apache2 not in PATH])
+      fi
+    fi
+  fi
 fi
-AC_SUBST(APACHECTL)
+AC_SUBST(HTTPD)
 
-if test -x "$APACHECTL"; then
-    DSO_MODULES="$($APACHECTL -t -D DUMP_MODULES | fgrep '(shared)'| sed 's/_module.*//g'|tr -d \\n)"
+if test -x "$HTTPD"; then
+    DSO_MODULES="$($HTTPD -t -D DUMP_MODULES | fgrep '(shared)'| sed 's/_module.*//g'|tr -d \\n)"
     AC_SUBST(DSO_MODULES)
-    STATIC_MODULES="$($APACHECTL -t -D DUMP_MODULES | fgrep '(static)'| sed 's/_module.*//g'|tr -d \\n)"
+    STATIC_MODULES="$($HTTPD -t -D DUMP_MODULES | fgrep '(static)'| sed 's/_module.*//g'|tr -d \\n)"
     AC_SUBST(STATIC_MODULES)
 else
-    AC_MSG_WARN("apachectl not found in '$BINDIR', test suite will not work!")
-    APACHECTL=""
+    AC_MSG_WARN("httpd/apache2 not found in '$BINDIR', test suite will not work!")
+    HTTPD=""
 fi
 AC_SUBST(LOAD_LOG_CONFIG)
 AC_SUBST(LOAD_LOGIO)
@@ -390,5 +408,5 @@ AC_MSG_NOTICE([summary of build options:
     Libnghttp2:     ${LIBNGHTTP2_VERSION} (CFLAGS='${LIBNGHTTP2_CFLAGS}' LIBS='${LIBNGHTTP2_LIBS}')
     nghttp          ${NGHTTP:--}
     h2load          ${H2LOAD:--}
-    apachectl       ${APACHECTL:--}
+    httpd           ${HTTPD:--}
 ])

--- a/test/pyhttpd/conf/httpd.conf.template
+++ b/test/pyhttpd/conf/httpd.conf.template
@@ -1,8 +1,9 @@
 ServerName localhost
 ServerRoot "${server_dir}"
 
-DefaultRuntimeDir logs
-PidFile httpd.pid
+# not in 2.4.x
+#DefaultRuntimeDir logs
+PidFile "${server_dir}/logs/httpd.pid"
 
 Include "conf/modules.conf"
 

--- a/test/pyhttpd/conf/stop.conf.template
+++ b/test/pyhttpd/conf/stop.conf.template
@@ -5,8 +5,9 @@
 ServerName localhost
 ServerRoot "${server_dir}"
 
-DefaultRuntimeDir logs
-PidFile httpd.pid
+# not in 2.4.x
+#DefaultRuntimeDir logs
+PidFile "${server_dir}/logs/httpd.pid"
 
 Include "conf/modules.conf"
 

--- a/test/pyhttpd/config.ini.in
+++ b/test/pyhttpd/config.ini.in
@@ -1,7 +1,7 @@
 [global]
 curl_bin = curl
-nghttp = @NGHTTP@
-h2load = @H2LOAD@
+nghttp = nghttp
+h2load = h2load
 
 prefix = @prefix@
 exec_prefix = @exec_prefix@
@@ -12,7 +12,7 @@ libexecdir = @libexecdir@
 
 apr_bindir = @APR_BINDIR@
 apxs = @bindir@/apxs
-apachectl = @sbindir@/apachectl
+httpd = @HTTPD@
 
 [httpd]
 version = @HTTPD_VERSION@
@@ -22,6 +22,7 @@ static_modules = @STATIC_MODULES@
 mpm_modules = mpm_event mpm_worker
 
 [test]
+src_dir = @abs_top_srcdir@
 gen_dir = @abs_srcdir@/../gen
 http_port = 5002
 https_port = 5001

--- a/test/pyhttpd/log.py
+++ b/test/pyhttpd/log.py
@@ -150,3 +150,7 @@ class HttpdErrorLog:
                     raise TimeoutError(f"pattern not found in error log after {timeout} seconds")
                 time.sleep(.1)
         return False
+
+    def dump(self, logger):
+        for line in open(self.path).readlines():
+            logger.error(f'httpd: {line}')


### PR DESCRIPTION
No longer rely on 'apachectl' which is heavily mutilated on several distros and use httpd/apache2 directly. Also improve error output on failure to start/stop the server.