### PR TITLE
test_200_17+18: check remote.emitted count fix

### DIFF
--- a/mod_http2/h2_session.c
+++ b/mod_http2/h2_session.c
@@ -363,9 +363,11 @@ static int on_frame_recv_cb(nghttp2_session *ng2s,
         else {
             ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, session->c1,
                           H2_SSSN_LOG(APLOGNO(03066), session,
-                          "recv FRAME[%s], frames=%ld/%ld (r/s)"),
+                          "recv FRAME[%s], frames=%ld/%ld (r/s), "
+                          "remote.emitted=%d"),
                           buffer, (long)session->frames_received,
-                         (long)session->frames_sent);
+                         (long)session->frames_sent,
+                         (int)session->remote.emitted_count);
         }
     }
 

--- a/test/modules/http2/test_200_header_invalid.py
+++ b/test/modules/http2/test_200_header_invalid.py
@@ -246,7 +246,8 @@ class TestInvalidHeaders:
         conf.add_vhost_cgi()
         conf.install()
         assert env.apache_restart() == 0
-        re_emitted = re.compile(r'.* AH03401: .* shutdown, remote.emitted=1')
+        re_emitted = re.compile(r'.* (AH03401: .* shutdown,|'
+                                r'AH03066: .* FRAME\[GOAWAY.*) remote.emitted=1')
         url = env.mkurl("https", "cgi", "/")
         opt = []
         for i in range(10):
@@ -266,7 +267,8 @@ class TestInvalidHeaders:
         conf.add_vhost_cgi()
         conf.install()
         assert env.apache_restart() == 0
-        re_emitted = re.compile(r'.* AH03401: .* shutdown, remote.emitted=1')
+        re_emitted = re.compile(r'.* (AH03401: .* shutdown,|'
+                                r'AH03066: .* FRAME\[GOAWAY.*) remote.emitted=1')
         url = env.mkurl("https", "cgi", "/")
         opt = []
         for i in range(100):


### PR DESCRIPTION
Newer curl versions send a GOAWAY frame rapidly after the response is received, making the test_200_17+18 fail since the desired log statement does not appear.

Add the log output where the GOAWAY is received and check for that in the test cases in addition.

Thanks to Rainer Jung for finding the cause of these failures.