### PR TITLE
Fix 304 responses from mod_cache

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+  * Fix issue with handling 304 responses from mod_cache. PR69580.
+
 v2.0.30
 --------------------------------------------------------------------------------
   * Fixed bug in handling over long response headers. When the 64 KB limit

--- a/mod_http2/h2_mplx.c
+++ b/mod_http2/h2_mplx.c
@@ -29,6 +29,7 @@
 #include <http_connection.h>
 #include <http_log.h>
 #include <http_protocol.h>
+#include <scoreboard.h>
 
 #include <mpm_common.h>
 
@@ -975,7 +976,9 @@ static void s_c2_done(h2_mplx *m, conn_rec *c2, h2_conn_ctx_t *conn_ctx)
     /* From here on, the final handling of c2 is done by c1 processing.
      * Which means we can give it c1's scoreboard handle for updates. */
     c2->sbh = m->c1->sbh;
-
+#if AP_MODULE_MAGIC_AT_LEAST(20211221, 29)
+    ap_set_time_process_request(c2->sbh,conn_ctx->started_at,conn_ctx->done_at);
+#endif
     ap_log_cerror(APLOG_MARK, APLOG_TRACE2, 0, c2,
                   "h2_mplx(%s-%d): request done, %f ms elapsed",
                   conn_ctx->id, conn_ctx->stream_id,

--- a/mod_http2/h2_session.c
+++ b/mod_http2/h2_session.c
@@ -637,7 +637,7 @@ static int on_frame_not_send_cb(nghttp2_session *ngh2,
     stream = get_stream(session, stream_id);
     h2_util_frame_print(frame, buffer, sizeof(buffer)/sizeof(buffer[0]));
     ap_log_cerror(APLOG_MARK, APLOG_ERR, 0, session->c1,
-                  H2_SSSN_LOG(APLOGNO(), session,
+                  H2_SSSN_LOG(APLOGNO(10509), session,
                   "not sent FRAME[%s], error %d: %s"),
                   buffer, ngh2_err, nghttp2_strerror(ngh2_err));
     if(stream) {


### PR DESCRIPTION
Fix issue with handling 304 responses from mod_cache. PR69580. Also, include changes for scoreboard interaction that work with httpd trunk only for now.