### PR TITLE
fix PR 68624

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+  * mod_proxy_http2: revert r1912193 for detecting broken backend connections
+    as this interferes with backend selection who a node is unresponsive.
+    PR69624.
   * Fix issue with handling 304 responses from mod_cache. PR69580.
 
 v2.0.30

--- a/mod_http2/h2_proxy_session.c
+++ b/mod_http2/h2_proxy_session.c
@@ -1681,17 +1681,7 @@ static int done_iter(void *udata, void *val)
     h2_proxy_stream *stream = val;
     int touched = (stream->data_sent || stream->data_received ||
                    stream->id <= ctx->session->last_stream_id);
-    if (touched && stream->output) {
-      apr_bucket *b = ap_bucket_error_create(HTTP_BAD_GATEWAY, NULL,
-                                             stream->r->pool,
-                                             stream->cfront->bucket_alloc);
-      APR_BRIGADE_INSERT_TAIL(stream->output, b);
-      b = apr_bucket_eos_create(stream->cfront->bucket_alloc);
-      APR_BRIGADE_INSERT_TAIL(stream->output, b);
-      ap_pass_brigade(stream->r->output_filters, stream->output);
-    }
-    ctx->done(ctx->session, stream->r, APR_ECONNABORTED, touched,
-              stream->error_code);
+    ctx->done(ctx->session, stream->r, APR_ECONNABORTED, touched, stream->error_code);
     return 1;
 }
 


### PR DESCRIPTION
  * mod_proxy_http2: revert r1912193 for detecting broken backend connections
    as this interferes with backend selection who a node is unresponsive.
    PR69624.