### PR TITLE
fix log2() undefined operations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+  * Fix a bug in calculating the log2 value of integers, used in push
+    diaries and proxy window size calculations. Apache PR69741.
+    [Benjamin P. Kallus]
+
 v2.0.33
 --------------------------------------------------------------------------------
   * Fixes CVE-2025-53020 (https://www.cve.org/CVERecord?id=CVE-2025-53020)

--- a/mod_http2/h2_proxy_util.c
+++ b/mod_http2/h2_proxy_util.c
@@ -34,7 +34,7 @@
 APLOG_USE_MODULE(proxy_http2);
 
 /* h2_log2(n) iff n is a power of 2 */
-unsigned char h2_proxy_log2(int n)
+unsigned char h2_proxy_log2(unsigned int n)
 {
     int lz = 0;
     if (!n) {

--- a/mod_http2/h2_proxy_util.h
+++ b/mod_http2/h2_proxy_util.h
@@ -150,7 +150,7 @@ int h2_proxy_iq_shift(h2_proxy_iqueue *q);
  * common helpers
  ******************************************************************************/
 /* h2_proxy_log2(n) iff n is a power of 2 */
-unsigned char h2_proxy_log2(int n);
+unsigned char h2_proxy_log2(unsigned int n);
 
 /*******************************************************************************
  * HTTP/2 header helpers

--- a/mod_http2/h2_util.c
+++ b/mod_http2/h2_util.c
@@ -32,7 +32,7 @@
 #include "h2_util.h"
 
 /* h2_log2(n) iff n is a power of 2 */
-unsigned char h2_log2(int n)
+unsigned char h2_log2(unsigned int n)
 {
     int lz = 0;
     if (!n) {

--- a/mod_http2/h2_util.h
+++ b/mod_http2/h2_util.h
@@ -323,7 +323,7 @@ apr_status_t h2_ififo_remove(h2_ififo *fifo, int id);
  * common helpers
  ******************************************************************************/
 /* h2_log2(n) iff n is a power of 2 */
-unsigned char h2_log2(int n);
+unsigned char h2_log2(unsigned int n);
 
 /**
  * Count the bytes that all key/value pairs in a table have


### PR DESCRIPTION
Fix a bug in calculating the log2 value of  integers, used in push diaries and proxy window size calculations. Apache PR69741 [Benjamin P. Kallus]