### PR TITLE
pytest: use classmethod instead of class property

### DIFF
--- a/test/modules/http2/env.py
+++ b/test/modules/http2/env.py
@@ -66,7 +66,6 @@ class H2TestSetup(HttpdTestSetup):
 class H2TestEnv(HttpdTestEnv):
 
     @classmethod
-    @property
     def is_unsupported(cls):
         mpm_module = f"mpm_{os.environ['MPM']}" if 'MPM' in os.environ else 'mpm_event'
         return mpm_module == 'mpm_prefork'

--- a/test/modules/http2/test_001_httpd_alive.py
+++ b/test/modules/http2/test_001_httpd_alive.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestBasicAlive:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_002_curl_basics.py
+++ b/test/modules/http2/test_002_curl_basics.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestCurlBasics:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_003_get.py
+++ b/test/modules/http2/test_003_get.py
@@ -6,7 +6,7 @@ from .env import H2Conf, H2TestEnv
 
 log = logging.getLogger(__name__)
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestGet:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_004_post.py
+++ b/test/modules/http2/test_004_post.py
@@ -12,7 +12,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestPost:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_005_files.py
+++ b/test/modules/http2/test_005_files.py
@@ -15,7 +15,7 @@ def mk_text_file(fpath: str, lines: int):
             fd.write("\n")
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestFiles:
 
     URI_PATHS = []

--- a/test/modules/http2/test_006_assets.py
+++ b/test/modules/http2/test_006_assets.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestAssets:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_007_ssi.py
+++ b/test/modules/http2/test_007_ssi.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestSSI:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_008_ranges.py
+++ b/test/modules/http2/test_008_ranges.py
@@ -11,7 +11,7 @@ from .env import H2Conf, H2TestEnv
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestRanges:
 
     LOGFILE = ""

--- a/test/modules/http2/test_009_timing.py
+++ b/test/modules/http2/test_009_timing.py
@@ -6,7 +6,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 @pytest.mark.skipif(not H2TestEnv().h2load_is_at_least('1.41.0'), reason="h2load misses --connect-to option")
 class TestTiming:
 

--- a/test/modules/http2/test_100_conn_reuse.py
+++ b/test/modules/http2/test_100_conn_reuse.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestConnReuse:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_101_ssl_reneg.py
+++ b/test/modules/http2/test_101_ssl_reneg.py
@@ -4,7 +4,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 @pytest.mark.skipif(H2TestEnv.get_ssl_module() != "mod_ssl", reason="only for mod_ssl")
 class TestSslRenegotiation:
 

--- a/test/modules/http2/test_102_require.py
+++ b/test/modules/http2/test_102_require.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestRequire:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_103_upgrade.py
+++ b/test/modules/http2/test_103_upgrade.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestUpgrade:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_104_padding.py
+++ b/test/modules/http2/test_104_padding.py
@@ -8,7 +8,7 @@ def frame_padding(payload, padbits):
     return ((payload + 9 + mask) & ~mask) - (payload + 9)
         
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestPadding:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_106_shutdown.py
+++ b/test/modules/http2/test_106_shutdown.py
@@ -11,7 +11,7 @@ from .env import H2Conf, H2TestEnv
 from pyhttpd.result import ExecResult
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestShutdown:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_107_frame_lengths.py
+++ b/test/modules/http2/test_107_frame_lengths.py
@@ -15,7 +15,7 @@ def mk_text_file(fpath: str, lines: int):
             fd.write("\n")
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestFrameLengths:
 
     URI_PATHS = []

--- a/test/modules/http2/test_200_header_invalid.py
+++ b/test/modules/http2/test_200_header_invalid.py
@@ -7,7 +7,7 @@ from .env import H2Conf, H2TestEnv
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestInvalidHeaders:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_201_header_conditional.py
+++ b/test/modules/http2/test_201_header_conditional.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestConditionalHeaders:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_300_interim.py
+++ b/test/modules/http2/test_300_interim.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestInterimResponses:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_400_push.py
+++ b/test/modules/http2/test_400_push.py
@@ -5,7 +5,7 @@ from .env import H2Conf, H2TestEnv
 
 
 # The push tests depend on "nghttp"
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestPush:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_401_early_hints.py
+++ b/test/modules/http2/test_401_early_hints.py
@@ -4,7 +4,7 @@ from .env import H2Conf, H2TestEnv
 
 
 # The push tests depend on "nghttp"
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestEarlyHints:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_500_proxy.py
+++ b/test/modules/http2/test_500_proxy.py
@@ -6,7 +6,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestProxy:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_501_proxy_serverheader.py
+++ b/test/modules/http2/test_501_proxy_serverheader.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestProxyServerHeader:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_502_proxy_port.py
+++ b/test/modules/http2/test_502_proxy_port.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestProxyPort:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_503_proxy_fwd.py
+++ b/test/modules/http2/test_503_proxy_fwd.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestProxyFwd:
 
     @classmethod

--- a/test/modules/http2/test_600_h2proxy.py
+++ b/test/modules/http2/test_600_h2proxy.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestH2Proxy:
 
     def test_h2_600_01(self, env):

--- a/test/modules/http2/test_601_h2proxy_twisted.py
+++ b/test/modules/http2/test_601_h2proxy_twisted.py
@@ -9,7 +9,7 @@ from .env import H2Conf, H2TestEnv
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestH2ProxyTwisted:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_700_load_get.py
+++ b/test/modules/http2/test_700_load_get.py
@@ -3,7 +3,7 @@ import pytest
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 @pytest.mark.skipif(not H2TestEnv().h2load_is_at_least('1.41.0'),
                     reason="h2load misses --connect-to option")
 class TestLoadGet:

--- a/test/modules/http2/test_710_load_post_static.py
+++ b/test/modules/http2/test_710_load_post_static.py
@@ -4,7 +4,7 @@ import os
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestLoadPostStatic:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_711_load_post_cgi.py
+++ b/test/modules/http2/test_711_load_post_cgi.py
@@ -4,7 +4,7 @@ import os
 from .env import H2Conf, H2TestEnv
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestLoadCgi:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_712_buffering.py
+++ b/test/modules/http2/test_712_buffering.py
@@ -6,7 +6,7 @@ from .env import H2Conf, H2TestEnv
 from pyhttpd.curl import CurlPiper
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 class TestBuffering:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/test/modules/http2/test_800_websockets.py
+++ b/test/modules/http2/test_800_websockets.py
@@ -84,7 +84,7 @@ def ws_run(env: H2TestEnv, path, authority=None, do_input=None, inbytes=None,
                       stdout=b'', stderr=b'', duration=end - start), infos, frames
 
 
-@pytest.mark.skipif(condition=H2TestEnv.is_unsupported, reason="mod_http2 not supported here")
+@pytest.mark.skipif(condition=H2TestEnv.is_unsupported(), reason="mod_http2 not supported here")
 @pytest.mark.skipif(condition=not H2TestEnv().httpd_is_at_least("2.4.60"),
                     reason=f'need at least httpd 2.4.60 for this')
 @pytest.mark.skipif(condition=ws_version < ws_version_min,


### PR DESCRIPTION
Some python version seem to have problems with that.