### PR TITLE
fix map_link in h2_proxy_util

### DIFF
--- a/mod_http2/h2_proxy_util.c
+++ b/mod_http2/h2_proxy_util.c
@@ -966,11 +966,8 @@ static void map_link(link_ctx *ctx)
             apr_cpystrn(buffer, ctx->p_server_uri, sizeof(buffer));
             buffer_len = ctx->psu_len;
         }
-        if (need_len > sizeof(buffer)) {
-            ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, ctx->r, APLOGNO(03482) 
-                          "link_reverse_map uri too long, skipped: %s", ctx->s);
-            return;
-        }
+        if (need_len > sizeof(buffer))
+            goto out;
         apr_cpystrn(buffer + buffer_len, ctx->s + ctx->link_start, link_len + 1);
         if (!prepend_p_server
             && strcmp(ctx->real_backend_uri, ctx->p_server_uri)
@@ -979,6 +976,9 @@ static void map_link(link_ctx *ctx)
              * to work, we need to use the proxy uri */
             int path_start = ctx->link_start + ctx->rbu_len;
             link_len -= ctx->rbu_len;
+            need_len = ctx->psu_len + link_len;
+            if (need_len > sizeof(buffer))
+                goto out;
             memcpy(buffer, ctx->p_server_uri, ctx->psu_len);
             memcpy(buffer + ctx->psu_len, ctx->s + path_start, link_len);
             buffer_len = ctx->psu_len + link_len;
@@ -998,6 +998,11 @@ static void map_link(link_ctx *ctx)
                 }
             }
             subst_str(ctx, ctx->link_start, ctx->link_end, mapped);
+        }
+out:
+        if (need_len > sizeof(buffer)) {
+            ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, ctx->r, APLOGNO(03482)
+                          "link_reverse_map uri too long, skipped: %s", ctx->s);
         }
     }
 }


### PR DESCRIPTION
When re-mapping the url scheme, the buffer may be overwritten by up to 3 bytes on a link exceeding ~8k. Recheck when mapping uri scheme.